### PR TITLE
3 double drop

### DIFF
--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -8,7 +8,7 @@ from torch.utils.data import Dataset, Subset
 class CIFAR10DMSubset(CIFAR10DataModule):
     def __init__(
         self,
-        train_dataset: Union[Subset, Dataset],
+        dataset_train: Union[Subset, Dataset],
         data_dir: Optional[str] = None,
         val_split: Union[int, float] = 0.2,
         num_workers: int = 0,
@@ -25,7 +25,8 @@ class CIFAR10DMSubset(CIFAR10DataModule):
         **kwargs: Any,
     ) -> None:
         """
-        A modified CIFAR10DataModule class that drops a % of the train set
+        A modified CIFAR10DataModule class that takes a Subset as input and replaces
+        the original training dataset with this Subset
 
         Args:
             drop: % of training data to drop when using dataloader
@@ -66,14 +67,14 @@ class CIFAR10DMSubset(CIFAR10DataModule):
         )
 
         # Change the dataset from original CIFAR10 DM
-        self.dataset_train = train_dataset
+        self.dataset_train = dataset_train
 
 
 class DMPair:
     def __init__(
         self,
-        drop_A: Union[int, float] = 0,
-        drop_B: Union[int, float] = 0,
+        drop_percent_A: Union[int, float] = 0,
+        drop_percent_B: Union[int, float] = 0,
         data_dir: Optional[str] = None,
         val_split: Union[int, float] = 0.2,
         num_workers: int = 0,
@@ -88,100 +89,129 @@ class DMPair:
         test_transforms: Optional[Callable] = None,
         *args: Any,
         **kwargs: Any,
-    ):
+    ) -> None:
+
+        """
+        A class to generate and manage two paired datamodules, including
+        specifying non-overlapping portions of the original dataset to be dropped
+
+        Args:
+            drop_percent_A: % of training data to drop from A
+            drop_percent_B: % of training data to drop from B
+            data_dir: Where to save/load the data
+            val_split: Percent (float) or number (int) of samples to use
+                       for the validation split
+            num_workers: How many workers to use for loading data
+            normalize: If true applies image normalize
+            batch_size: How many samples per batch to load
+            seed: Random seed to be used for train/val/test splits and
+                  random dropping of observations
+            shuffle: If true shuffles the train data every epoch
+            pin_memory: If true, the data loader will copy Tensors into
+                        CUDA pinned memory before
+                        returning them
+            drop_last: If true drops the last incomplete batch
+            train_transforms: transformations you can apply to train dataset
+            val_transforms: transformations you can apply to validation dataset
+            test_transforms: transformations you can apply to test dataset
+        """
+
         # Assign params
-        self.drop_A = drop_A
-        self.drop_B = drop_B
+        self.drop_percent_A = drop_percent_A
+        self.drop_percent_B = drop_percent_B
         self.seed = seed
 
         # Load and setup CIFAR
-        cifar = CIFAR10DataModule()
+        cifar = CIFAR10DataModule(val_split=val_split, seed=self.seed)
         cifar.prepare_data()
         cifar.setup()
 
-        # If not dropping any observations
-        if (self.drop_A + self.drop_B) == 0:
-            self.A = cifar
-            self.B = cifar
+        # Default
+        self.indices_core = cifar.dataset_train.indices
+        labels_core = [i[1] for i in cifar.dataset_train]
+        self.keep_inds_A = []
+        self.keep_inds_B = []
 
         # If needing to drop observations
-        if (self.drop_A + self.drop_B) > 0:
-
-            # Set up indices and labels
-            self._train_indices = cifar.dataset_train.indices
-            self._train_labels = [i[1] for i in cifar.dataset_train]
-
-            # Defaults
-            a_inds = []
-            b_inds = []
+        if (self.drop_percent_A + self.drop_percent_B) > 0:
 
             # Split (drop_A + drop_B)% of the training data
-            self._main_indices, self._drop_indices = train_test_split(
-                self._train_indices,
-                test_size=self.drop_A + self.drop_B,  # drop all together
-                stratify=self._train_labels,
+            self.indices_core, drop_indices = train_test_split(
+                self.indices_core,
+                test_size=self.drop_percent_A
+                + self.drop_percent_B,  # drop all together
+                stratify=labels_core,
                 random_state=self.seed,
             )
-            unselected_labels = [
-                cifar.dataset_train.dataset.targets[i] for i in self._drop_indices
+            labels_unselected = [
+                cifar.dataset_train.dataset.targets[i] for i in drop_indices
             ]
 
             # If dropping only from A
-            if self.drop_A > 0 and self.drop_B == 0:
-                b_inds = unselected_labels
+            if self.drop_percent_A > 0 and self.drop_percent_B == 0:
+                self.keep_inds_B = drop_indices
 
             # If dropping only from B
-            if self.drop_A == 0 and self.drop_B > 0:
-                a_inds = unselected_labels
+            if self.drop_percent_A == 0 and self.drop_percent_B > 0:
+                self.keep_inds_A = drop_indices
 
             # If dropping from both
-            if (self.drop_A > 0) and (self.drop_B > 0):
+            if (self.drop_percent_A > 0) and (self.drop_percent_B > 0):
 
                 # Split the unselected component into parts to keep/drop in A vs B
                 # since B is test, test amount is proportion of unselected that is B
-                a_inds, b_inds = train_test_split(
-                    self._drop_indices,
-                    test_size=self.drop_B / (self.drop_A + self.drop_B),
-                    stratify=unselected_labels,
+                self.keep_inds_A, self.keep_inds_B = train_test_split(
+                    drop_indices,
+                    test_size=self.drop_percent_B
+                    / (self.drop_percent_A + self.drop_percent_B),
+                    stratify=labels_unselected,
                     random_state=self.seed,
                 )
 
-            # Store indices
-            self.indices_A = self._main_indices + a_inds
-            self.indices_B = self._main_indices + b_inds
+        # Store indices
+        self.indices_A = self.indices_core + self.keep_inds_A
+        self.indices_B = self.indices_core + self.keep_inds_B
 
-            # Create data modules
-            self.A = CIFAR10DMSubset(
-                train_dataset=Subset(cifar.dataset_train, self.indices_A),
-                data_dir=data_dir,
-                val_split=val_split,
-                num_workers=num_workers,
-                normalize=normalize,
-                batch_size=batch_size,
-                seed=seed,
-                shuffle=shuffle,
-                pin_memory=pin_memory,
-                drop_last=drop_last,
-                train_transforms=train_transforms,
-                val_transforms=val_transforms,
-                test_transforms=test_transforms,
-                *args,
-                **kwargs,
-            )
-            self.B = CIFAR10DMSubset(
-                train_dataset=Subset(cifar.dataset_train, self.indices_B),
-                data_dir=data_dir,
-                val_split=val_split,
-                num_workers=num_workers,
-                normalize=normalize,
-                batch_size=batch_size,
-                seed=seed,
-                shuffle=shuffle,
-                pin_memory=pin_memory,
-                drop_last=drop_last,
-                train_transforms=train_transforms,
-                val_transforms=val_transforms,
-                test_transforms=test_transforms,
-                *args,
-                **kwargs,
-            )
+        # Create data modules
+        self.A = CIFAR10DMSubset(
+            dataset_train=Subset(cifar.dataset_train, self.indices_A),
+            data_dir=data_dir,
+            val_split=val_split,
+            num_workers=num_workers,
+            normalize=normalize,
+            batch_size=batch_size,
+            seed=seed,
+            shuffle=shuffle,
+            pin_memory=pin_memory,
+            drop_last=drop_last,
+            train_transforms=train_transforms,
+            val_transforms=val_transforms,
+            test_transforms=test_transforms,
+            *args,
+            **kwargs,
+        )
+        self.B = CIFAR10DMSubset(
+            dataset_train=Subset(cifar.dataset_train, self.indices_B),
+            data_dir=data_dir,
+            val_split=val_split,
+            num_workers=num_workers,
+            normalize=normalize,
+            batch_size=batch_size,
+            seed=seed,
+            shuffle=shuffle,
+            pin_memory=pin_memory,
+            drop_last=drop_last,
+            train_transforms=train_transforms,
+            val_transforms=val_transforms,
+            test_transforms=test_transforms,
+            *args,
+            **kwargs,
+        )
+
+        # Store labels
+        self.labels_A = [
+            self.A.dataset_train.dataset.dataset.targets[i] for i in self.indices_A
+        ]
+        self.labels_B = [
+            self.B.dataset_train.dataset.dataset.targets[i] for i in self.indices_B
+        ]

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -69,6 +69,10 @@ class CIFAR10DMSubset(CIFAR10DataModule):
         # Change the dataset from original CIFAR10 DM
         self.dataset_train = dataset_train
 
+    # Override original setup message to avoid restoring CIFAR observations
+    def setup(self, stage: Optional[str] = None) -> None:
+        return None
+
 
 def split_indices(
     indices: list[int],

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -29,8 +29,8 @@ class CIFAR10DMSubset(CIFAR10DataModule):
         the original training dataset with this Subset
 
         Args:
-            drop: % of training data to drop when using dataloader
-            keep: whether in the 'unselected' component to keep A or B
+            dataset_train: Dataset or Subset class object to replace
+                           original dataset_train with
             data_dir: Where to save/load the data
             val_split: Percent (float) or number (int) of samples to use
                        for the validation split
@@ -128,7 +128,7 @@ class DMPair:
 
         # Default
         self.indices_core = cifar.dataset_train.indices
-        labels_core = [i[1] for i in cifar.dataset_train]
+        labels_core = [image[1] for image in cifar.dataset_train]
         self.keep_inds_A = []
         self.keep_inds_B = []
 
@@ -174,7 +174,7 @@ class DMPair:
 
         # Create data modules
         self.A = CIFAR10DMSubset(
-            dataset_train=Subset(cifar.dataset_train, self.indices_A),
+            dataset_train=Subset(cifar.dataset_train.dataset, self.indices_A),
             data_dir=data_dir,
             val_split=val_split,
             num_workers=num_workers,
@@ -191,7 +191,7 @@ class DMPair:
             **kwargs,
         )
         self.B = CIFAR10DMSubset(
-            dataset_train=Subset(cifar.dataset_train, self.indices_B),
+            dataset_train=Subset(cifar.dataset_train.dataset, self.indices_B),
             data_dir=data_dir,
             val_split=val_split,
             num_workers=num_workers,
@@ -210,8 +210,8 @@ class DMPair:
 
         # Store labels
         self.labels_A = [
-            self.A.dataset_train.dataset.dataset.targets[i] for i in self.indices_A
+            self.A.dataset_train.dataset.targets[i] for i in self.indices_A
         ]
         self.labels_B = [
-            self.B.dataset_train.dataset.dataset.targets[i] for i in self.indices_B
+            self.B.dataset_train.dataset.targets[i] for i in self.indices_B
         ]

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -138,10 +138,10 @@ def split_indices(
                 random_state=seed,
             )
 
-        # Return
-        indices_A = shared_AB_indices + indices_kept_A_dropped_B
-        indices_B = shared_AB_indices + indices_kept_B_dropped_A
-        return indices_A, indices_B
+    # Return
+    indices_A = shared_AB_indices + indices_kept_A_dropped_B
+    indices_B = shared_AB_indices + indices_kept_B_dropped_A
+    return indices_A, indices_B
 
 
 class DMPair:

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -78,7 +78,13 @@ def split_indices(
     seed: int,
     cifar: CIFAR10DataModule,
 ) -> tuple[list[int], list[int]]:
-    """_summary_
+    """
+    A function that takes as input a list of indices and a list of
+    labels. It returns two lists of indices, A and B, that have dropped
+    indices with respect to the input. Importantly however, the indices
+    they drop are non-overlapping with respect to each other, and the label
+    proportions in A and B are the same as the input, while allowing for
+    some rounding error.
 
     Args:
         indices (list[int]): Indices to be split across 2 datasets

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -87,16 +87,15 @@ def split_indices(
     some rounding error.
 
     Args:
-        indices (list[int]): Indices to be split across 2 datasets
-        labels (list[int]): Labels corresponding to the indices
-        drop_percent_A (float): Percentage of data to drop from A
-        drop_percent_B (float): Percentage of data to drop from B
-        seed (int): Seed for random splitting
-        cifar (CIFAR10DataModule): CIFAR datamodule to use in extracting
-                                   stratifying the second split
+        indices: Indices to be split across 2 datasets
+        labels: Labels corresponding to the indices
+        drop_percent_A: Percentage of data to drop from A
+        drop_percent_B: Percentage of data to drop from B
+        seed: Seed for random splitting
+        cifar: CIFAR datamodule to use in stratifying the
+               second split according to labels
 
-    Returns:
-        tuple[list[int], list[int]]: Two lists containing indices for A and B
+    Returns: Two lists containing indices for A and B
     """
 
     # Defaults

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -250,6 +250,7 @@ class DMPair:
         )
 
         # Store labels
+        # List comprehension because pytorch dataset makes it necsesary
         self.labels_A = [
             self.A.dataset_train.dataset.targets[i] for i in self.indices_A
         ]

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -300,6 +300,8 @@ class DMPair:
         )
 
         # Create data modules
+        # NB A and B MUST use the same seed as each other and as the cifar used
+        # to generate their training datasets
         self.cifar = cifar  # necessary for some tests
         logging.warning("Performing early loading of CIFARDM10Subset.dataset_train")
         self.A = CIFAR10DMSubset(

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -285,6 +285,7 @@ class DMPair:
         # Load and setup CIFAR
         cifar = CIFAR10DataModule(val_split=val_split, seed=self.seed)
         cifar.prepare_data()
+        logging.warning("Performing early loading of CIFARDM10Subset.dataset_train")
         cifar.setup()
 
         # Default
@@ -303,7 +304,6 @@ class DMPair:
         # NB A and B MUST use the same seed as each other and as the cifar used
         # to generate their training datasets
         self.cifar = cifar  # necessary for some tests
-        logging.warning("Performing early loading of CIFARDM10Subset.dataset_train")
         self.A = CIFAR10DMSubset(
             dataset_train=Subset(cifar.dataset_train.dataset, self.indices_A),
             data_dir=data_dir,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from copy import deepcopy
 from math import isclose
 
 from modsim2.data.loader import CIFAR10DataModuleDrop
@@ -34,3 +35,28 @@ def test_drop_loader_stratification():
         for i in range(9)
     ]
     assert all(count_test)
+
+
+def test_drop_loader_double_overlap():
+    # Generate datasets A and B. Drop 10% from both with no overlap
+    drop = 0.1
+    cifar_A = CIFAR10DataModuleDrop(drop=drop)
+    cifar_B = deepcopy(cifar_A)
+    cifar_B.keep = "B"
+
+    # Set up the datasets
+    cifar_A.prepare_data()
+    cifar_A.setup()
+    cifar_B.prepare_data()
+    cifar_B.setup()
+    dl_A = cifar_A.train_dataloader()
+    dl_B = cifar_B.train_dataloader()
+
+    # Extract indices from both datasets to work as lists
+    indices_A = set(dl_A.dataset.indices)
+    indices_B = set(dl_B.dataset.indices)
+
+    # Since no overlap in data dropped, if we drop x obs, both shld contain
+    # N-x obs, with x obs not in the other. Shared obs should therefore be equal
+    # to N-2x
+    assert len(indices_A & indices_B) == len(dl_A.dataset.dataset) * (1 - drop * 2)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,22 +6,17 @@ from modsim2.data.loader import DMPair
 
 def test_cifar_pair_n_obs():
     drop = 0.1
-    dmpair = DMPair(drop_A=drop, drop_B=0)
-    dl_A = dmpair.A.train_dataloader()
-    dl_B = dmpair.B.train_dataloader()
-    assert len(dl_A.dataset) == (1 - drop) * len(dl_B.dataset)
+    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=0)
+    assert len(set(dmpair.indices_A)) == (1 - drop) * len(set(dmpair.indices_B))
 
 
 def test_cifar_pair_stratification():
     drop = 0.1
-    dmpair = DMPair(drop_A=drop)
+    dmpair = DMPair(drop_percent_A=drop)
 
     # Extract labels from full and subsetted dataset
     full_labels = [i[1] for i in dmpair.A.dataset_train.dataset]
-    subset_labels = [
-        dmpair.A.dataset_train.dataset.dataset.targets[i]
-        for i in dmpair.A.dataset_train.indices
-    ]
+    subset_labels = dmpair.labels_A
 
     # Get count of labels in each dataset
     full_count = Counter(full_labels)
@@ -38,13 +33,12 @@ def test_cifar_pair_stratification():
 def test_cifar_pair_overlap():
     # Generate datasets A and B. Drop 10% from both with no overlap
     drop = 0.1
-    dmpair = DMPair(drop_A=drop, drop_B=drop)
+    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
     dl_A = dmpair.A.train_dataloader()
-    dl_B = dmpair.B.train_dataloader()
 
-    # Get indices
-    indices_A = set(dl_A.dataset.indices)
-    indices_B = set(dl_B.dataset.indices)
+    # Get indices, put into set
+    indices_A = set(dmpair.indices_A)
+    indices_B = set(dmpair.indices_B)
 
     # Since no overlap in data dropped, if we drop x obs, both shld contain
     # N-x obs, with x obs not in the other. Shared obs should therefore be equal

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,23 +1,32 @@
 from collections import Counter
-from math import isclose
+from math import ceil, isclose
 
 from modsim2.data.loader import DMPair
 
 
-def test_cifar_pair_n_obs():
-    drop = 0.1
-    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=0)
-    assert len(set(dmpair.indices_A)) == (1 - drop) * len(set(dmpair.indices_B))
+def _test_dm_n_obs(
+    length_subset: int,
+    length_full: int,
+    drop: float,
+) -> None:
+    assert length_subset == (1 - drop) * length_full
 
 
-def test_cifar_pair_stratification():
+def test_cifar_A_n_obs():
     drop = 0.1
     dmpair = DMPair(drop_percent_A=drop)
+    _test_dm_n_obs(len(dmpair.A.dataset_train), len(dmpair.cifar.dataset_train), drop)
 
-    # Extract labels from full and subsetted dataset
-    full_labels = [i[1] for i in dmpair.A.dataset_train.dataset]
-    subset_labels = dmpair.labels_A
 
+def test_cifar_B_n_obs():
+    drop = 0.1
+    dmpair = DMPair(drop_percent_B=drop)
+    _test_dm_n_obs(len(dmpair.B.dataset_train), len(dmpair.cifar.dataset_train), drop)
+
+
+def _test_dm_stratification(
+    full_labels: list[int], subset_labels: list[int], drop: float
+) -> None:
     # Get count of labels in each dataset
     full_count = Counter(full_labels)
     subset_count = Counter(subset_labels)
@@ -30,17 +39,80 @@ def test_cifar_pair_stratification():
     assert all(count_test)
 
 
-def test_cifar_pair_overlap():
-    # Generate datasets A and B. Drop 10% from both with no overlap
+def test_cifar_A_stratification():
     drop = 0.1
     dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
-    dl_A = dmpair.A.train_dataloader()
+    full_labels = [image[1] for image in dmpair.cifar.dataset_train]
+    _test_dm_stratification(full_labels, dmpair.labels_A, drop=drop)
 
+
+def test_cifar_B_stratification():
+    drop = 0.1
+    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
+    full_labels = [image[1] for image in dmpair.cifar.dataset_train]
+    _test_dm_stratification(full_labels, dmpair.labels_B, drop=drop)
+
+
+def _test_dm_overlap(
+    indices_A: list[int],
+    indices_B: list[int],
+    drop_percentage_A: float,
+    drop_percentage_B: float,
+    original_size: int,
+) -> None:
     # Get indices, put into set
-    indices_A = set(dmpair.indices_A)
-    indices_B = set(dmpair.indices_B)
+    indices_A = set(indices_A)
+    indices_B = set(indices_B)
 
-    # Since no overlap in data dropped, if we drop x obs, both shld contain
-    # N-x obs, with x obs not in the other. Shared obs should therefore be equal
-    # to N-2x
-    assert len(indices_A & indices_B) == len(dl_A.dataset.dataset) * (1 - drop * 2)
+    # Below is based on notion that there should be no overlap in data
+    # dropped from both datasets
+    total_drop_percentage = drop_percentage_A + drop_percentage_B
+    shared_size = original_size * (1 - total_drop_percentage)
+    assert len(indices_A & indices_B) == shared_size
+
+
+def test_cifar_pair_overlap_same_size():
+    drop = 0.1
+    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
+    original_size = len(dmpair.cifar.dataset_train)
+    _test_dm_overlap(
+        dmpair.indices_A,
+        dmpair.indices_B,
+        dmpair.drop_percent_A,
+        dmpair.drop_percent_B,
+        original_size,
+    )
+
+
+def test_cifar_pair_overlap_diff_size():
+    dmpair = DMPair(drop_percent_A=0.1, drop_percent_B=0.2)
+    original_size = len(dmpair.cifar.dataset_train)
+    _test_dm_overlap(
+        dmpair.indices_A,
+        dmpair.indices_B,
+        dmpair.drop_percent_A,
+        dmpair.drop_percent_B,
+        original_size,
+    )
+
+
+def _test_cifar_dataloader_batch_count(data_loader, batch_size):
+    dataset_size = len(data_loader.dataset)
+    count = 0
+    for batch in data_loader:
+        count += 1
+    assert count == ceil(dataset_size / batch_size)
+
+
+def test_cifar_A_batch_count():
+    batch_size = 32
+    dmpair = DMPair(drop_percent_A=0.175, batch_size=batch_size)
+    dla = dmpair.A.train_dataloader()
+    _test_cifar_dataloader_batch_count(dla, batch_size)
+
+
+def test_cifar_B_batch_count():
+    batch_size = 32
+    dmpair = DMPair(drop_percent_B=0.175, batch_size=batch_size)
+    dla = dmpair.B.train_dataloader()
+    _test_cifar_dataloader_batch_count(dla, batch_size)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,7 +7,7 @@ from modsim2.data.loader import CIFAR10DataModuleDrop
 
 def test_drop_loader_n_obs():
     drop = 0.1
-    cifar = CIFAR10DataModuleDrop(drop=drop)
+    cifar = CIFAR10DataModuleDrop(drop_A=drop)
     cifar.prepare_data()
     cifar.setup()
     dl = cifar.train_dataloader()
@@ -16,7 +16,7 @@ def test_drop_loader_n_obs():
 
 def test_drop_loader_stratification():
     drop = 0.1
-    cifar = CIFAR10DataModuleDrop(drop=drop)
+    cifar = CIFAR10DataModuleDrop(drop_A=drop)
     cifar.prepare_data()
     cifar.setup()
     dl = cifar.train_dataloader()
@@ -40,7 +40,7 @@ def test_drop_loader_stratification():
 def test_drop_loader_double_overlap():
     # Generate datasets A and B. Drop 10% from both with no overlap
     drop = 0.1
-    cifar_A = CIFAR10DataModuleDrop(drop=drop)
+    cifar_A = CIFAR10DataModuleDrop(drop_A=drop, drop_B=drop)
     cifar_B = deepcopy(cifar_A)
     cifar_B.keep = "B"
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,25 +3,28 @@ from math import ceil, isclose
 
 from modsim2.data.loader import DMPair
 
+# Constants for testing
+VAL_SPLIT = 0.2
+CIFAR_10_TRAIN_SIZE = 40000
+
 
 def _test_dm_n_obs(
     length_subset: int,
-    length_full: int,
     drop: float,
 ) -> None:
-    assert length_subset == (1 - drop) * length_full
+    assert length_subset == (1 - drop) * CIFAR_10_TRAIN_SIZE
 
 
 def test_cifar_A_n_obs():
     drop = 0.1
-    dmpair = DMPair(drop_percent_A=drop)
-    _test_dm_n_obs(len(dmpair.A.dataset_train), len(dmpair.cifar.dataset_train), drop)
+    dmpair = DMPair(drop_percent_A=drop, val_split=VAL_SPLIT)
+    _test_dm_n_obs(len(dmpair.A.dataset_train), drop)
 
 
 def test_cifar_B_n_obs():
     drop = 0.1
-    dmpair = DMPair(drop_percent_B=drop)
-    _test_dm_n_obs(len(dmpair.B.dataset_train), len(dmpair.cifar.dataset_train), drop)
+    dmpair = DMPair(drop_percent_B=drop, val_split=VAL_SPLIT)
+    _test_dm_n_obs(len(dmpair.B.dataset_train), drop)
 
 
 def _test_dm_stratification(
@@ -58,7 +61,6 @@ def _test_dm_overlap(
     indices_B: list[int],
     drop_percentage_A: float,
     drop_percentage_B: float,
-    original_size: int,
 ) -> None:
     # Get indices, put into set
     indices_A = set(indices_A)
@@ -67,32 +69,22 @@ def _test_dm_overlap(
     # Below is based on notion that there should be no overlap in data
     # dropped from both datasets
     total_drop_percentage = drop_percentage_A + drop_percentage_B
-    shared_size = original_size * (1 - total_drop_percentage)
+    shared_size = CIFAR_10_TRAIN_SIZE * (1 - total_drop_percentage)
     assert len(indices_A & indices_B) == shared_size
 
 
 def test_cifar_pair_overlap_same_size():
     drop = 0.1
-    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
-    original_size = len(dmpair.cifar.dataset_train)
+    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop, val_split=VAL_SPLIT)
     _test_dm_overlap(
-        dmpair.indices_A,
-        dmpair.indices_B,
-        dmpair.drop_percent_A,
-        dmpair.drop_percent_B,
-        original_size,
+        dmpair.indices_A, dmpair.indices_B, dmpair.drop_percent_A, dmpair.drop_percent_B
     )
 
 
 def test_cifar_pair_overlap_diff_size():
-    dmpair = DMPair(drop_percent_A=0.1, drop_percent_B=0.2)
-    original_size = len(dmpair.cifar.dataset_train)
+    dmpair = DMPair(drop_percent_A=0.1, drop_percent_B=0.2, val_split=VAL_SPLIT)
     _test_dm_overlap(
-        dmpair.indices_A,
-        dmpair.indices_B,
-        dmpair.drop_percent_A,
-        dmpair.drop_percent_B,
-        original_size,
+        dmpair.indices_A, dmpair.indices_B, dmpair.drop_percent_A, dmpair.drop_percent_B
     )
 
 


### PR DESCRIPTION
These commits do 2 broad things to contribute to #3:

- Turn the `CIFAR10DataModuleDrop` class's dataloader into one that can mange dropping the same % from both A and B, while still being useful for the case where we only want to drop from one but not the other
- Adds a test to ensure that when dropping from both, we get complete non-overlap as expected