### PR TITLE
16 network training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # CIFAR
 cifar-10-python.tar.gz
 cifar-10-batches-py/
+
+# Training logs
+logs/

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Dict, Optional, Union
 from pl_bolts.datamodules import CIFAR10DataModule
 from sklearn.model_selection import train_test_split
 from torch.utils.data import Dataset, Subset
-from torchvision.transforms import transforms
 
 from modsim2.similarity.constants import ARGUMENTS, FUNCTION, METRIC_FN_DICT
 
@@ -97,7 +96,7 @@ class CIFAR10DMSubset(CIFAR10DataModule):
                 else self.val_transforms
             )
 
-            self.dataset_train.dataset.transform = transforms.Compose(train_transforms)
+            self.dataset_train.dataset.transform = train_transforms
             dataset_val = self.dataset_cls(
                 self.data_dir, train=True, transform=val_transforms, **self.EXTRA_ARGS
             )

--- a/src/modsim2/model/resnet.py
+++ b/src/modsim2/model/resnet.py
@@ -17,7 +17,9 @@ def create_model(num_classes=10, channels=3):
 
     Returns: ResNet18 model
     """
+    # pretrained=False to avoid messing up our modification to conv1 below
     model = torchvision.models.resnet18(pretrained=False, num_classes=num_classes)
+
     # ResNet is designed for ImageNet which has high res images;
     # use a smaller kernel size for CIFAR-10.
     model.conv1 = torch.nn.Conv2d(

--- a/src/modsim2/model/resnet.py
+++ b/src/modsim2/model/resnet.py
@@ -8,14 +8,14 @@ from torchmetrics import Accuracy
 
 
 def create_model(num_classes=10, channels=3):
-    """_summary_
+    """
+    Function to create a resnet18 model for CIAFAR-10.
 
     Args:
-        num_classes (int, optional): _description_. Defaults to 10.
-        channels (int, optional): _description_. Defaults to 3.
+        num_classes: Number of classes in the dataset
+        channels: Number of channels in the image
 
-    Returns:
-        _type_: _description_
+    Returns: ResNet18 model
     """
     model = torchvision.models.resnet18(pretrained=False, num_classes=num_classes)
     # ResNet is designed for ImageNet which has high res images;
@@ -29,7 +29,7 @@ def create_model(num_classes=10, channels=3):
 
 class ResnetModel(pl.LightningModule):
     """
-    PyTorch Lightning module for models considered in project.
+    ResNet18 model lightning module for use in project
     """
 
     def __init__(

--- a/src/modsim2/model/resnet.py
+++ b/src/modsim2/model/resnet.py
@@ -1,0 +1,108 @@
+# Modified from mod sim phase 1 code
+
+import pytorch_lightning as pl
+import torch
+import torch.nn.functional as F
+import torchvision
+from torchmetrics import Accuracy
+
+
+def create_model(num_classes=10, channels=3):
+    """_summary_
+
+    Args:
+        num_classes (int, optional): _description_. Defaults to 10.
+        channels (int, optional): _description_. Defaults to 3.
+
+    Returns:
+        _type_: _description_
+    """
+    model = torchvision.models.resnet18(pretrained=False, num_classes=num_classes)
+    # ResNet is designed for ImageNet which has high res images;
+    # use a smaller kernel size for CIFAR-10.
+    model.conv1 = torch.nn.Conv2d(
+        channels, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False
+    )
+    model.maxpool = torch.nn.Identity()
+    return model
+
+
+class ResnetModel(pl.LightningModule):
+    """
+    PyTorch Lightning module for models considered in project.
+    """
+
+    def __init__(
+        self,
+        num_classes=10,
+        lr=0.05,
+        weight_decay=0.0005,
+        batch_size=32,
+        train_size=50000,
+        channels=3,
+    ):
+        super().__init__()
+        self.model = create_model(num_classes=num_classes, channels=channels)
+        self.num_classes = num_classes
+        if num_classes == 2:
+            self.task = "binary"
+        if num_classes > 2:
+            self.task = "multiclass"
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.steps_per_epoch = train_size // batch_size
+        self.optimizer = None
+
+    def forward(self, x):
+        out = self.model(x)
+        return torch.log_softmax(out, dim=1)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = F.nll_loss(logits, y)
+        self.log(
+            "train_loss",
+            loss,
+            prog_bar=True,
+            logger=True,
+        )
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = F.nll_loss(logits, y)
+        preds = torch.argmax(logits, dim=1)
+        accuracy = Accuracy(task=self.task, num_classes=self.num_classes, top_k=1)
+        acc = accuracy(preds, y)
+        self.log("val_loss", loss, on_epoch=True, prog_bar=True, logger=True)
+        self.log("val_acc", acc, on_epoch=True, prog_bar=True, logger=True)
+
+    def on_train_epoch_end(self):
+        self.log(
+            "lr",
+            self.optimizer.param_groups[0]["lr"],
+            on_epoch=True,
+            on_step=False,
+            prog_bar=False,
+            logger=True,
+        )
+
+    def configure_optimizers(self):
+        self.optimizer = torch.optim.SGD(
+            self.parameters(),
+            lr=self.lr,
+            momentum=0.9,
+            weight_decay=self.weight_decay,
+        )
+        scheduler_dict = {
+            "scheduler": torch.optim.lr_scheduler.OneCycleLR(
+                self.optimizer,
+                0.1,
+                epochs=self.trainer.max_epochs,
+                steps_per_epoch=self.steps_per_epoch,
+            ),
+            "interval": "step",
+        }
+        return {"optimizer": self.optimizer, "lr_scheduler": scheduler_dict}

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,22 +7,23 @@ from pytorch_lightning.loggers import CSVLogger
 from modsim2.data.loader import DMPair
 from modsim2.model.resnet import ResnetModel
 
-# Constants for testing model running and training
-dmpair = DMPair(val_split=testing_constants.VAL_SPLIT)
-model = ResnetModel(lr=0.05)
-trainer = Trainer(
-    max_epochs=1,
-    max_steps=2,
-    devices=None,
-    logger=CSVLogger(save_dir="logs/test_logs/"),
-    callbacks=[
-        LearningRateMonitor(logging_interval="step"),
-        TQDMProgressBar(refresh_rate=10),
-    ],
-)
-
 
 def test_model_runs():
+    # Set up trainer
+    dmpair = DMPair(val_split=testing_constants.VAL_SPLIT)
+    model = ResnetModel(lr=0.05)
+    trainer = Trainer(
+        max_epochs=1,
+        max_steps=2,
+        devices=None,
+        logger=CSVLogger(save_dir="logs/test_logs/"),
+        callbacks=[
+            LearningRateMonitor(logging_interval="step"),
+            TQDMProgressBar(refresh_rate=10),
+        ],
+    )
+
+    # Make sure that it runs
     try:
         trainer.fit(model, dmpair.A)
     except Exception as exc:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,29 @@
+import testing_constants
+from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import LearningRateMonitor
+from pytorch_lightning.callbacks.progress import TQDMProgressBar
+from pytorch_lightning.loggers import CSVLogger
+
+from modsim2.data.loader import DMPair
+from modsim2.model.resnet import ResnetModel
+
+# Constants for testing model running and training
+dmpair = DMPair(val_split=testing_constants.VAL_SPLIT)
+model = ResnetModel(lr=0.05)
+trainer = Trainer(
+    max_epochs=1,
+    max_steps=2,
+    devices=None,
+    logger=CSVLogger(save_dir="logs/test_logs/"),
+    callbacks=[
+        LearningRateMonitor(logging_interval="step"),
+        TQDMProgressBar(refresh_rate=10),
+    ],
+)
+
+
+def test_model_runs():
+    try:
+        trainer.fit(model, dmpair.A)
+    except Exception as exc:
+        assert False, f"trainer.fit raised an exception: {exc}"


### PR DESCRIPTION
This PR completes #16 and contributes to #19. This PR includes:

- A resnet18 model modified from phase 1 code
- An accompanying pytorch lightning module (also modified from phase 1 code)
- Fixes a bug in our Cifar Subset class that causes trainer.fit to fail
- Adds a test to check that the model does indeed train

In the future, we may wish to:

- Consider better optimising our use of the resent model given recent literature
- Add a config for the model (if we want to play around with some settings externally to the package)