### PR TITLE
23 manipulate val

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,10 @@ dmypy.json
 # CIFAR
 cifar-10-python.tar.gz
 cifar-10-batches-py/
+
+#lightning logs
+logs/
+
+#vscode
+launch.json
+settings.json

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -1,11 +1,10 @@
 import logging
-from typing import Any, Callable, Dict, Optional, Union, Tuple, List
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+import torch
 from pl_bolts.datamodules import CIFAR10DataModule
 from sklearn.model_selection import train_test_split
 from torch.utils.data import Dataset, Subset
-from torchvision.transforms import transforms
-import torch
 
 from modsim2.similarity.constants import ARGUMENTS, FUNCTION, METRIC_FN_DICT
 
@@ -112,7 +111,7 @@ class CIFAR10DMSubset(CIFAR10DataModule):
             self.dataset_test = self.dataset_cls(
                 self.data_dir, train=False, transform=test_transforms, **self.EXTRA_ARGS
             )
-            
+
     def prepare_data(self):
         # override parent and do nothing
         pass
@@ -227,7 +226,6 @@ def split_indices(
             )
             shared_AB_indices = []
 
-
     # Return
     indices_A = shared_AB_indices + indices_kept_A_dropped_B
     indices_B = shared_AB_indices + indices_kept_B_dropped_A
@@ -304,7 +302,7 @@ class DMPair:
             seed=self.seed,
             cifar=cifar,
         )
-        val_indices_A, val_indices_B =  split_indices(
+        val_indices_A, val_indices_B = split_indices(
             indices=cifar.dataset_val.indices,
             labels=[image[1] for image in cifar.dataset_val],
             drop_percent_A=self.drop_percent_A,
@@ -355,15 +353,15 @@ class DMPair:
         )
 
     # TODO consider val?
-    def compute_similarity(self, only_train: bool=False):
-        """ 
-        compute similarity between data of A and B 
+    def compute_similarity(self, only_train: bool = False):
+        """
+        compute similarity between data of A and B
         only_train removes the validation data from this comparison
         """
         # coerce data into single tensor (not subset)
         train_data_A, val_data_A = self.get_A_data()
         train_data_B, val_data_B = self.get_B_data()
-        
+
         if not only_train:
             data_A = torch.concat((train_data_A, val_data_A))
             data_B = torch.concat((train_data_B, val_data_B))
@@ -384,7 +382,9 @@ class DMPair:
     """ convenience methods below for getting data/labels from subsets """
 
     @staticmethod
-    def _get_subset_data(subset_module: CIFAR10DMSubset) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _get_subset_data(
+        subset_module: CIFAR10DMSubset,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         train = subset_module.dataset_train.dataset.data[
             subset_module.dataset_train.indices
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
+import logging
 from unittest.mock import patch
 
 import pytest
 import testing_constants
 from pl_bolts.datamodules import CIFAR10DataModule
 from pl_bolts.datasets.cifar10_dataset import CIFAR10
-import logging
 
 
 # same structure as CIFAR10 but doesn't require a download
@@ -31,7 +31,8 @@ def patch_datamodule():
     with patch("modsim2.data.loader.CIFAR10DataModule", new=MockCIFAR10DataModule):
         # patch for inheritance within CIFAR10DMSubset
         # alternative is to monkey patch in each test
-        # annoyingly need to catch exception on exit of mock as it messes up removing itself
+        # annoyingly need to catch exception on exit of mock as
+        #  it messes up removing itself
         try:
             with patch(
                 "modsim2.data.loader.CIFAR10DMSubset.__bases__",
@@ -39,10 +40,11 @@ def patch_datamodule():
             ):
                 yield None
         except TypeError as e:
-            # make sure it's the error we're expected and just pass if so - should be fine as used for all tests
+            # make sure it's the error we're expected and just pass if so
+            # should be fine as used for all tests
             if (
                 str(e)
-                == "cannot delete '__bases__' attribute of immutable type 'CIFAR10DMSubset'"
+                == "cannot delete '__bases__' attribute of immutable type 'CIFAR10DMSubset'"  # noqa: E501
             ):
                 # warn
                 logging.warning("Failed to delete mock on CIFAR10DMSubset inheritace.")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -17,12 +17,20 @@ def _test_dm_n_obs(
     assert len(datamodule_subset.dataset_val) == round((1 - drop) * orig_val_size)
 
 
+def test_cifar_empty_val():
+    drop_A = 0.2
+    val_split = 0
+    dmpair = DMPair(drop_percent_A=drop_A, val_split=val_split)
+    # test A
+    _test_dm_n_obs(datamodule_subset=dmpair.A, drop=drop_A, val_split=val_split)
+    # test B
+    _test_dm_n_obs(datamodule_subset=dmpair.B, drop=0.0, val_split=val_split)
+
+
 def test_cifar_A_n_obs():
     drop_A = 0.2
     val_split = 0.4
     dmpair = DMPair(drop_percent_A=drop_A, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
     # test A
     _test_dm_n_obs(datamodule_subset=dmpair.A, drop=drop_A, val_split=val_split)
     # test B
@@ -33,8 +41,6 @@ def test_cifar_B_n_obs():
     drop_B = 0.3
     val_split = 0.4
     dmpair = DMPair(drop_percent_B=drop_B, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
     # test A
     _test_dm_n_obs(datamodule_subset=dmpair.A, drop=0.0, val_split=val_split)
     # test B
@@ -46,8 +52,6 @@ def test_cifar_both_n_obs():
     drop_B = 0.3
     val_split = 0.4
     dmpair = DMPair(drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
     # test A
     _test_dm_n_obs(datamodule_subset=dmpair.A, drop=drop_A, val_split=val_split)
     # test B
@@ -74,8 +78,6 @@ def test_cifar_stratification():
     drop_B = 0.3
     val_split = 0.4
     dmpair = DMPair(drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
     full_train_labels = [image[1] for image in dmpair.cifar.dataset_train]
     full_val_labels = [image[1] for image in dmpair.cifar.dataset_val]
     # test A
@@ -112,8 +114,6 @@ def _test_dm_overlap_split(
 
 def _test_dm_overlap(drop_A: float, drop_B: float, val_split: float):
     dmpair = DMPair(drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
 
     orig_train_size = round(testing_constants.DUMMY_CIFAR10_SIZE * (1 - val_split))
     orig_val_size = testing_constants.DUMMY_CIFAR10_SIZE - orig_train_size
@@ -151,7 +151,7 @@ def test_cifar_pair_overlap_diff_size():
 def _test_cifar_dataloader_batch_count(data_loader, batch_size):
     dataset_size = len(data_loader.dataset)
     count = 0
-    for batch in data_loader:
+    for _ in data_loader:
         count += 1
     assert count == ceil(dataset_size / batch_size)
 
@@ -160,8 +160,6 @@ def test_cifar_A_batch_count():
     batch_size = 32
     val_split = 0.4
     dmpair = DMPair(drop_percent_A=0.175, batch_size=batch_size, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
     _test_cifar_dataloader_batch_count(dmpair.A.train_dataloader(), batch_size)
     _test_cifar_dataloader_batch_count(dmpair.A.val_dataloader(), batch_size)
 
@@ -170,7 +168,5 @@ def test_cifar_B_batch_count():
     batch_size = 32
     val_split = 0.4
     dmpair = DMPair(drop_percent_B=0.175, batch_size=batch_size, val_split=val_split)
-    dmpair.A.setup()
-    dmpair.B.setup()
     _test_cifar_dataloader_batch_count(dmpair.B.train_dataloader(), batch_size)
     _test_cifar_dataloader_batch_count(dmpair.B.val_dataloader(), batch_size)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,26 +3,56 @@ from math import ceil, isclose
 
 import testing_constants
 
-from modsim2.data.loader import DMPair
+from modsim2.data.loader import DMPair, CIFAR10DMSubset
+
 
 
 def _test_dm_n_obs(
-    length_subset: int,
+    datamodule_subset: CIFAR10DMSubset,
     drop: float,
+    val_split: float,
 ) -> None:
-    assert length_subset == (1 - drop) * testing_constants.DUMMY_CIFAR10_TRAIN_SIZE
+    orig_train_size = testing_constants.DUMMY_CIFAR10_SIZE * (1 - val_split)
+    orig_val_size = testing_constants.DUMMY_CIFAR10_SIZE * val_split
+    assert len(datamodule_subset.dataset_train) == round((1 - drop) * orig_train_size)
+    assert len(datamodule_subset.dataset_val) == round((1 - drop) * orig_val_size)
 
 
 def test_cifar_A_n_obs():
-    drop = 0.1
-    dmpair = DMPair(drop_percent_A=drop, val_split=testing_constants.VAL_SPLIT)
-    _test_dm_n_obs(len(dmpair.A.dataset_train), drop)
+    drop_A = 0.2
+    val_split = 0.4
+    dmpair = DMPair(drop_percent_A=drop_A, val_split=val_split)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    # test A
+    _test_dm_n_obs(datamodule_subset=dmpair.A, drop=drop_A, val_split=val_split)
+    # test B
+    _test_dm_n_obs(datamodule_subset=dmpair.B, drop=0.0, val_split=val_split)
 
 
 def test_cifar_B_n_obs():
-    drop = 0.1
-    dmpair = DMPair(drop_percent_B=drop, val_split=testing_constants.VAL_SPLIT)
-    _test_dm_n_obs(len(dmpair.B.dataset_train), drop)
+    drop_B = 0.3
+    val_split = 0.4
+    dmpair = DMPair(drop_percent_B=drop_B, val_split=val_split)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    # test A
+    _test_dm_n_obs(datamodule_subset=dmpair.A, drop=0.0, val_split=val_split)
+    # test B
+    _test_dm_n_obs(datamodule_subset=dmpair.B, drop=drop_B, val_split=val_split)
+
+
+def test_cifar_both_n_obs():
+    drop_A = 0.2
+    drop_B = 0.3
+    val_split = 0.4
+    dmpair = DMPair(drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    # test A
+    _test_dm_n_obs(datamodule_subset=dmpair.A, drop=drop_A, val_split=val_split)
+    # test B
+    _test_dm_n_obs(datamodule_subset=dmpair.B, drop=drop_B, val_split=val_split)
 
 
 def _test_dm_stratification(
@@ -40,25 +70,37 @@ def _test_dm_stratification(
     assert all(count_test)
 
 
-def test_cifar_A_stratification():
-    drop = 0.1
-    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
-    full_labels = [image[1] for image in dmpair.cifar.dataset_train]
-    _test_dm_stratification(full_labels, dmpair.labels_A, drop=drop)
+def test_cifar_stratification():
+    drop_A = 0.2
+    drop_B = 0.3
+    val_split = 0.4
+    dmpair = DMPair(drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    full_train_labels = [image[1] for image in dmpair.cifar.dataset_train]
+    full_val_labels = [image[1] for image in dmpair.cifar.dataset_val]
+    # test A
+    train_labels_A, val_labels_A = dmpair.get_A_labels()
+    train_labels_B, val_labels_B = dmpair.get_B_labels()
+    _test_dm_stratification(full_train_labels, train_labels_A, drop=drop_A)
+    # test B
+    _test_dm_stratification(full_train_labels, train_labels_B, drop=drop_B)
+
+    #val
+    #test A
+    _test_dm_stratification(full_val_labels, val_labels_A, drop=drop_A)
+    # test B
+    _test_dm_stratification(full_val_labels, val_labels_B, drop=drop_B)
+
+    
 
 
-def test_cifar_B_stratification():
-    drop = 0.1
-    dmpair = DMPair(drop_percent_A=drop, drop_percent_B=drop)
-    full_labels = [image[1] for image in dmpair.cifar.dataset_train]
-    _test_dm_stratification(full_labels, dmpair.labels_B, drop=drop)
-
-
-def _test_dm_overlap(
+def _test_dm_overlap_split(
     indices_A: list[int],
     indices_B: list[int],
     drop_percentage_A: float,
     drop_percentage_B: float,
+    orig_total_size: int
 ) -> None:
     # Get indices, put into set
     indices_A = set(indices_A)
@@ -67,29 +109,49 @@ def _test_dm_overlap(
     # Below is based on notion that there should be no overlap in data
     # dropped from both datasets
     total_drop_percentage = drop_percentage_A + drop_percentage_B
-    shared_size = testing_constants.DUMMY_CIFAR10_TRAIN_SIZE * (
+    shared_size = orig_total_size * (
         1 - total_drop_percentage
     )
     assert len(indices_A & indices_B) == shared_size
 
-
-def test_cifar_pair_overlap_same_size():
-    drop = 0.1
+def _test_dm_overlap(drop_A: float, drop_B: float, val_split: float):
     dmpair = DMPair(
-        drop_percent_A=drop, drop_percent_B=drop, val_split=testing_constants.VAL_SPLIT
+        drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split
     )
-    _test_dm_overlap(
-        dmpair.indices_A, dmpair.indices_B, dmpair.drop_percent_A, dmpair.drop_percent_B
+    dmpair.A.setup()
+    dmpair.B.setup()
+
+    orig_train_size = round(testing_constants.DUMMY_CIFAR10_SIZE * (1-val_split))
+    orig_val_size = testing_constants.DUMMY_CIFAR10_SIZE - orig_train_size
+
+    _test_dm_overlap_split(
+        dmpair.A.dataset_train.indices,
+        dmpair.B.dataset_train.indices,
+        dmpair.drop_percent_A,
+        dmpair.drop_percent_B,
+        orig_total_size=orig_train_size
     )
+
+    _test_dm_overlap_split(
+        dmpair.A.dataset_val.indices,
+        dmpair.B.dataset_val.indices,
+        dmpair.drop_percent_A,
+        dmpair.drop_percent_B,
+        orig_total_size=orig_val_size
+    )
+def test_cifar_pair_overlap_same_size():
+    drop = 0.2
+    val_split=0.4
+    _test_dm_overlap(drop_A=drop, drop_B=drop, val_split=val_split)
+    
 
 
 def test_cifar_pair_overlap_diff_size():
-    dmpair = DMPair(
-        drop_percent_A=0.1, drop_percent_B=0.2, val_split=testing_constants.VAL_SPLIT
-    )
-    _test_dm_overlap(
-        dmpair.indices_A, dmpair.indices_B, dmpair.drop_percent_A, dmpair.drop_percent_B
-    )
+    drop_A = 0.2
+    drop_B = 0.3
+    val_split = 0.4
+    _test_dm_overlap(drop_A=drop_A, drop_B=drop_B, val_split=val_split)
+
 
 
 def _test_cifar_dataloader_batch_count(data_loader, batch_size):
@@ -102,13 +164,22 @@ def _test_cifar_dataloader_batch_count(data_loader, batch_size):
 
 def test_cifar_A_batch_count():
     batch_size = 32
-    dmpair = DMPair(drop_percent_A=0.175, batch_size=batch_size)
-    dla = dmpair.A.train_dataloader()
-    _test_cifar_dataloader_batch_count(dla, batch_size)
+    val_split = 0.4
+    dmpair = DMPair(drop_percent_A=0.175, batch_size=batch_size, val_split=val_split)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    _test_cifar_dataloader_batch_count(dmpair.A.train_dataloader(), batch_size)
+    _test_cifar_dataloader_batch_count(dmpair.A.val_dataloader(), batch_size)
+
 
 
 def test_cifar_B_batch_count():
     batch_size = 32
-    dmpair = DMPair(drop_percent_B=0.175, batch_size=batch_size)
-    dla = dmpair.B.train_dataloader()
-    _test_cifar_dataloader_batch_count(dla, batch_size)
+    val_split = 0.4
+    dmpair = DMPair(drop_percent_B=0.175, batch_size=batch_size, val_split=val_split)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    _test_cifar_dataloader_batch_count(dmpair.B.train_dataloader(), batch_size)
+    _test_cifar_dataloader_batch_count(dmpair.B.val_dataloader(), batch_size)
+
+

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,8 +3,7 @@ from math import ceil, isclose
 
 import testing_constants
 
-from modsim2.data.loader import DMPair, CIFAR10DMSubset
-
+from modsim2.data.loader import CIFAR10DMSubset, DMPair
 
 
 def _test_dm_n_obs(
@@ -86,13 +85,11 @@ def test_cifar_stratification():
     # test B
     _test_dm_stratification(full_train_labels, train_labels_B, drop=drop_B)
 
-    #val
-    #test A
+    # val
+    # test A
     _test_dm_stratification(full_val_labels, val_labels_A, drop=drop_A)
     # test B
     _test_dm_stratification(full_val_labels, val_labels_B, drop=drop_B)
-
-    
 
 
 def _test_dm_overlap_split(
@@ -100,7 +97,7 @@ def _test_dm_overlap_split(
     indices_B: list[int],
     drop_percentage_A: float,
     drop_percentage_B: float,
-    orig_total_size: int
+    orig_total_size: int,
 ) -> None:
     # Get indices, put into set
     indices_A = set(indices_A)
@@ -109,19 +106,16 @@ def _test_dm_overlap_split(
     # Below is based on notion that there should be no overlap in data
     # dropped from both datasets
     total_drop_percentage = drop_percentage_A + drop_percentage_B
-    shared_size = orig_total_size * (
-        1 - total_drop_percentage
-    )
+    shared_size = orig_total_size * (1 - total_drop_percentage)
     assert len(indices_A & indices_B) == shared_size
 
+
 def _test_dm_overlap(drop_A: float, drop_B: float, val_split: float):
-    dmpair = DMPair(
-        drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split
-    )
+    dmpair = DMPair(drop_percent_A=drop_A, drop_percent_B=drop_B, val_split=val_split)
     dmpair.A.setup()
     dmpair.B.setup()
 
-    orig_train_size = round(testing_constants.DUMMY_CIFAR10_SIZE * (1-val_split))
+    orig_train_size = round(testing_constants.DUMMY_CIFAR10_SIZE * (1 - val_split))
     orig_val_size = testing_constants.DUMMY_CIFAR10_SIZE - orig_train_size
 
     _test_dm_overlap_split(
@@ -129,7 +123,7 @@ def _test_dm_overlap(drop_A: float, drop_B: float, val_split: float):
         dmpair.B.dataset_train.indices,
         dmpair.drop_percent_A,
         dmpair.drop_percent_B,
-        orig_total_size=orig_train_size
+        orig_total_size=orig_train_size,
     )
 
     _test_dm_overlap_split(
@@ -137,13 +131,14 @@ def _test_dm_overlap(drop_A: float, drop_B: float, val_split: float):
         dmpair.B.dataset_val.indices,
         dmpair.drop_percent_A,
         dmpair.drop_percent_B,
-        orig_total_size=orig_val_size
+        orig_total_size=orig_val_size,
     )
+
+
 def test_cifar_pair_overlap_same_size():
     drop = 0.2
-    val_split=0.4
+    val_split = 0.4
     _test_dm_overlap(drop_A=drop, drop_B=drop, val_split=val_split)
-    
 
 
 def test_cifar_pair_overlap_diff_size():
@@ -151,7 +146,6 @@ def test_cifar_pair_overlap_diff_size():
     drop_B = 0.3
     val_split = 0.4
     _test_dm_overlap(drop_A=drop_A, drop_B=drop_B, val_split=val_split)
-
 
 
 def _test_cifar_dataloader_batch_count(data_loader, batch_size):
@@ -172,7 +166,6 @@ def test_cifar_A_batch_count():
     _test_cifar_dataloader_batch_count(dmpair.A.val_dataloader(), batch_size)
 
 
-
 def test_cifar_B_batch_count():
     batch_size = 32
     val_split = 0.4
@@ -181,5 +174,3 @@ def test_cifar_B_batch_count():
     dmpair.B.setup()
     _test_cifar_dataloader_batch_count(dmpair.B.train_dataloader(), batch_size)
     _test_cifar_dataloader_batch_count(dmpair.B.val_dataloader(), batch_size)
-
-

--- a/tests/test_mmd.py
+++ b/tests/test_mmd.py
@@ -43,4 +43,3 @@ def test_cifar_mmd_different_train_only():
     expected_mmd_laplace = 0.0010416666666666664
     assert similarity_dict["mmd_rbf"] == expected_mmd_rbf
     assert similarity_dict["mmd_laplace"] == expected_mmd_laplace
-

--- a/tests/test_mmd.py
+++ b/tests/test_mmd.py
@@ -14,13 +14,33 @@ METRIC_CONFIG = CONFIGS["metric_config"]
 
 def test_cifar_mmd_same():
     dmpair = DMPair(metric_config=METRIC_CONFIG)
+    dmpair.A.setup()
+    dmpair.B.setup()
     similarity_dict = dmpair.compute_similarity()
     assert similarity_dict["mmd_rbf"] == 0
     assert similarity_dict["mmd_laplace"] == 0
 
 
 def test_cifar_mmd_different():
-    dmpair = DMPair(metric_config=METRIC_CONFIG, drop_percent_A=0.2)
+    dmpair = DMPair(metric_config=METRIC_CONFIG, drop_percent_A=0.2, seed=42)
+    dmpair.A.setup()
+    dmpair.B.setup()
     similarity_dict = dmpair.compute_similarity()
-    assert similarity_dict["mmd_rbf"] > 0
-    assert similarity_dict["mmd_laplace"] > 0
+    # known values for this seed - brittle test but useful for messing with code
+    expected_mmd_rbf = 0.0008333333333333326
+    expected_mmd_laplace = 0.0008333333333333326
+    assert similarity_dict["mmd_rbf"] == expected_mmd_rbf
+    assert similarity_dict["mmd_laplace"] == expected_mmd_laplace
+
+
+def test_cifar_mmd_different_train_only():
+    dmpair = DMPair(metric_config=METRIC_CONFIG, drop_percent_A=0.2, seed=42)
+    dmpair.A.setup()
+    dmpair.B.setup()
+    similarity_dict = dmpair.compute_similarity(only_train=True)
+    # known values for this seed - brittle test but useful for messing with code
+    expected_mmd_rbf = 0.0010416666666666664
+    expected_mmd_laplace = 0.0010416666666666664
+    assert similarity_dict["mmd_rbf"] == expected_mmd_rbf
+    assert similarity_dict["mmd_laplace"] == expected_mmd_laplace
+

--- a/tests/test_mmd.py
+++ b/tests/test_mmd.py
@@ -14,8 +14,7 @@ METRIC_CONFIG = CONFIGS["metric_config"]
 
 def test_cifar_mmd_same():
     dmpair = DMPair(metric_config=METRIC_CONFIG)
-    dmpair.A.setup()
-    dmpair.B.setup()
+
     similarity_dict = dmpair.compute_similarity()
     assert similarity_dict["mmd_rbf"] == 0
     assert similarity_dict["mmd_laplace"] == 0
@@ -23,8 +22,6 @@ def test_cifar_mmd_same():
 
 def test_cifar_mmd_different():
     dmpair = DMPair(metric_config=METRIC_CONFIG, drop_percent_A=0.2, seed=42)
-    dmpair.A.setup()
-    dmpair.B.setup()
     similarity_dict = dmpair.compute_similarity()
     # known values for this seed - brittle test but useful for messing with code
     expected_mmd_rbf = 0.0008333333333333326
@@ -35,8 +32,6 @@ def test_cifar_mmd_different():
 
 def test_cifar_mmd_different_train_only():
     dmpair = DMPair(metric_config=METRIC_CONFIG, drop_percent_A=0.2, seed=42)
-    dmpair.A.setup()
-    dmpair.B.setup()
     similarity_dict = dmpair.compute_similarity(only_train=True)
     # known values for this seed - brittle test but useful for messing with code
     expected_mmd_rbf = 0.0010416666666666664

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,7 @@
-import testing_constants
+import os
+import shutil
+
+import pytest
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import LearningRateMonitor
 from pytorch_lightning.callbacks.progress import TQDMProgressBar
@@ -7,16 +10,26 @@ from pytorch_lightning.loggers import CSVLogger
 from modsim2.data.loader import DMPair
 from modsim2.model.resnet import ResnetModel
 
+LOG_DIR = "tmp/test_logs/"
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown():
+    os.makedirs(LOG_DIR, exist_ok=False)
+    yield
+    # teardown
+    shutil.rmtree(LOG_DIR)
+
 
 def test_model_runs():
     # Set up trainer
-    dmpair = DMPair(val_split=testing_constants.VAL_SPLIT)
+    dmpair = DMPair(val_split=0.2)
     model = ResnetModel(lr=0.05)
     trainer = Trainer(
         max_epochs=1,
         max_steps=2,
         devices=None,
-        logger=CSVLogger(save_dir="logs/test_logs/"),
+        logger=CSVLogger(save_dir=LOG_DIR),
         callbacks=[
             LearningRateMonitor(logging_interval="step"),
             TQDMProgressBar(refresh_rate=10),

--- a/tests/testing_constants.py
+++ b/tests/testing_constants.py
@@ -1,8 +1,6 @@
 import os
 
-VAL_SPLIT = 0.2
 DUMMY_CIFAR10_SIZE = 300
-DUMMY_CIFAR10_TRAIN_SIZE = DUMMY_CIFAR10_SIZE * (1 - VAL_SPLIT)
 DUMMY_CIFAR_DIR = os.path.abspath(
     os.path.join(__file__, os.pardir, "testdata", "dummy_cifar")
 )


### PR DESCRIPTION
perform same manipulation on validation set as on training.

validation set is now passed directly to `CIFAR10DMSubset` alongside training data rather than generated again.

some bits I don't love here like the patching in conftest and the repeated `.setup()` in `test_data.py` - happy to take suggestions for changes!