### PR TITLE
A and B transforms now applied to A and B test datasets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         additional_dependencies: ["toml"]

--- a/configs/transforms.yaml
+++ b/configs/transforms.yaml
@@ -19,12 +19,3 @@ B: # used for both train and val
   kwargs:
     mean: [0.4913725490196078, 0.4823529411764706, 0.4466666666666667] # init kwarg mean with values
     std: [0.24705882352941178, 0.24352941176470588, 0.2615686274509804] # init kwarg std with values
-
-
-test:
-  - name: ToTensor # class name, no kwargs specified
-
-  - name: Normalize # class name
-    kwargs:
-      mean: [0.4913725490196078, 0.4823529411764706, 0.4466666666666667] # init kwarg mean with values
-      std: [0.24705882352941178, 0.24352941176470588, 0.2615686274509804] # init kwarg std with values

--- a/src/modsim2/data/loader.py
+++ b/src/modsim2/data/loader.py
@@ -248,7 +248,6 @@ class DMPair:
         drop_percent_B: Union[int, float] = 0,
         transforms_A: Optional[Callable] = None,
         transforms_B: Optional[Callable] = None,
-        transforms_test: Optional[Callable] = None,
         data_dir: Optional[str] = None,
         val_split: Union[int, float] = 0.2,
         num_workers: int = 0,
@@ -327,7 +326,7 @@ class DMPair:
             drop_last=drop_last,
             train_transforms=transforms_A,
             val_transforms=transforms_A,
-            test_transforms=transforms_test,
+            test_transforms=transforms_A,
             *args,
             **kwargs,
         )
@@ -345,7 +344,7 @@ class DMPair:
             drop_last=drop_last,
             train_transforms=transforms_B,
             val_transforms=transforms_B,
-            test_transforms=transforms_test,
+            test_transforms=transforms_B,
             *args,
             **kwargs,
         )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -225,11 +225,9 @@ def _setup_transforms_test(
 
     output_A = torch.rand((3, 2, 2))
     output_B = torch.rand((3, 2, 2))
-    test_output = torch.rand((3, 2, 2))
 
     transforms_A_mock = MagicMock(return_value=output_A)
     transforms_B_mock = MagicMock(return_value=output_B)
-    test_transforms_mock = MagicMock(return_value=test_output)
 
     dmpair = DMPair(
         drop_percent_A=drop_A,
@@ -237,13 +235,12 @@ def _setup_transforms_test(
         val_split=val_split,
         transforms_A=transforms_A_mock,
         transforms_B=transforms_B_mock,
-        transforms_test=test_transforms_mock,
         batch_size=batch_size,
         drop_last=True,
     )
     dmpair.A.setup()
     dmpair.B.setup()
-    return dmpair, transforms_A_mock, transforms_B_mock, test_transforms_mock
+    return dmpair, transforms_A_mock, transforms_B_mock
 
 
 def _test_dl_transforms(
@@ -271,7 +268,6 @@ def test_transforms():
         dmpair,
         transforms_A_mock,
         transforms_B_mock,
-        test_transforms_mock,
     ) = _setup_transforms_test(batch_size=batch_size)
 
     # load orig raw data - for checking transforms called with orig data
@@ -312,14 +308,14 @@ def test_transforms():
 
     # test A
     _test_dl_transforms(
-        transforms_mock=test_transforms_mock,
+        transforms_mock=transforms_A_mock,
         batch_size=batch_size,
         dl=dmpair.A.test_dataloader(),
         raw_orig_data=reshaped_raw_test,
     )
     # test B
     _test_dl_transforms(
-        transforms_mock=test_transforms_mock,
+        transforms_mock=transforms_B_mock,
         batch_size=batch_size,
         dl=dmpair.B.test_dataloader(),
         raw_orig_data=reshaped_raw_test,

--- a/tests/testconfig/transforms.yaml
+++ b/tests/testconfig/transforms.yaml
@@ -14,11 +14,3 @@ B: # used for both train and val
   kwargs:
     mean: [0.3, 0.4 ,0.5] # init kwarg mean with values (different to A)
     std: [0.1, 0.2, 0.3] # init kwarg std with values
-
-test:
-  - name: ToTensor # class name, no kwargs specified
-
-  - name: Normalize # class name
-    kwargs:
-      mean: [0.2, 0.3 ,0.4] # init kwarg mean with values
-      std: [0.1, 0.2, 0.3] # init kwarg std with values


### PR DESCRIPTION
This PR resolves #38. It:

- Applies A and B transforms in the DMPair's input arguments to the A and B CIFAR10DMSubset test datasets respectively
- Removes the test transforms argument from the DMPair (as we now wish to transform A and B test datasets in line with A and B)
- Updates the relevant transforms tests
- Removes test transforms from both the current transforms config (which may not be needed once #33 is implemented, but this question is left for that PR) and the test transforms config