### PR TITLE
26 training regime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,5 @@ results/
 
 # Slurm outputs
 slurm_logs/
+slurm_train_logs/
+slurm_attack_logs/

--- a/configs/datasets.yaml
+++ b/configs/datasets.yaml
@@ -16,3 +16,10 @@ experiment_groups:
       B:
         drop: 0.5
         transforms: null
+
+    - A:
+        drop: 0.25
+        transforms: null
+      B:
+        drop: 0.75
+        transforms: null

--- a/configs/datasets.yaml
+++ b/configs/datasets.yaml
@@ -16,10 +16,3 @@ experiment_groups:
       B:
         drop: 0.5
         transforms: null
-
-    - A:
-        drop: 0.5
-        transforms: null
-      B:
-        drop: 0.0
-        transforms: null

--- a/configs/trainer.yaml
+++ b/configs/trainer.yaml
@@ -4,7 +4,9 @@ trainer_kwargs:
   accelerator: "auto"
 
 model:
-  lr: 0.05
+  lr: 0.0125
+  weight_decay: 0.0005
+  momentum: 0.9
 
 wandb:
   entity: turing-arc

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ Note that while measuring dataset similarity and model training can be performed
 
 For each of these three tasks, a generation script exists which will generate bash/slurm scripts that can be called individually for a given dataset pair.
 
-**Requirements:** For broad requirements beyond installing the project source code, see see [requirements](#requirements) below.
+**Requirements:** For broad requirements beyond installing the project source code, see [requirements](#requirements) below.
 
 **Important:** for model training and transfer attacks, we use wandb to store our results (see more in [requirements](#requirements) below). Our training script will produce an exception if the run name already exists on wandb, and the attack script will produce an exception if the run name is not unique on wandb. To perform the same run again, it will be necessary to either rename the old run, rename the new run, or delete the old run.
 
@@ -56,7 +56,7 @@ Alternatively, you can call each of the scripts individually, e.g.
 sbatch trainer_scripts/drop-only_0_0_trainer.sh
 ```
 
-to train models for that particular dataset pair, where `drop-only_0_0_trainer` is one of the bash scripts generated for the `drop-only` experiment group, with dataset pair index `0` and seed index `0`. Note that logging is performed with wandb and so you will need this set up on your machine in order to proceed.
+to train models for that particular dataset pair, where `drop-only_0_0_trainer` is one of the bash scripts generated for the `drop-only` experiment group, with dataset pair index `0` and seed index `0`. Note that logging is performed with wandb and so you will need this set up on your machine in order to proceed. Note also that the output directory specified in the slurm template (see [requirements](#requirements) below.)
 
 ## Transfer Attacks
 
@@ -88,13 +88,13 @@ sbatch attack_scripts/drop-only_0_0_attack.sh
 
 to perform transfer attacks for that particular dataset pair, where `drop-only_0_0_trainer` is one of the bash scripts generated for the `drop-only` experiment group, with dataset pair index `0` and seed index `0`.
 
-As stated above, note that a unique run must exist on wandb for the transfer attack to be performed. Results for model A as the surrogate model (i.e. with B as the target model) will be logged to model A on wandb, and vice versa for model B
+As stated above, note that a unique run must exist on wandb for the transfer attack to be performed. Results for model A as the surrogate model (i.e. with B as the target model) will be logged to model A on wandb, and vice versa for model B.  Note also that the output directory specified in the slurm template (see [requirements](#requirements) below.)
 
 ## Requirements
 
 ### Training Requirements
 
-The slurm scripts generated for model training contain some arguments specific to our HPC, and the templates will likely need some modifications to be appropriate to your own usage.
+The slurm scripts generated for model training contain some arguments specific to our HPC, and the templates will likely need some modifications to be appropriate to your own usage. See our [train template](/scripts/templates/slurm-train-template.sh) for specific arguments.
 
 Broadly, the requirements are:
 
@@ -105,6 +105,8 @@ Broadly, the requirements are:
 Please note in particular that the account name (passed to the generation script via `--account_name`) argument is specific to our HPC and may not be required for your usage.
 
 ### Transfer Attack Requirements
+
+The slurm scripts generated for the transfer attacks contain some arguments specific to our HPC, and the templates will likely need some modifications to be appropriate to your own usage. See our [transfer attack template](/scripts/templates/slurm-attack-template.sh) for specific arguments.
 
 For the transfer attack scripts to work, you will need models with the correct names and IDs on your wandb account.
 

--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -25,7 +25,7 @@ def train_model(dm: LightningDataModule, experiment_name: str, trainer_config: d
             "A run with this name already exists on wandb. Please rename or delete it."
         )
 
-    model = ResnetModel(**trainer_config["model"])
+    model = ResnetModel(**trainer_config["model"], train_size=len(dm.dataset_train))
 
     wandb_logger = MS2WandbLogger(
         entity=trainer_config["wandb"]["entity"],

--- a/src/modsim2/model/resnet.py
+++ b/src/modsim2/model/resnet.py
@@ -53,7 +53,7 @@ class ResnetModel(pl.LightningModule):
             self.task = "multiclass"
         self.lr = lr
         self.weight_decay = weight_decay
-        self.momentum = self.momentum
+        self.momentum = momentum
         self.steps_per_epoch = train_size // batch_size
         self.optimizer = None
 

--- a/src/modsim2/model/resnet.py
+++ b/src/modsim2/model/resnet.py
@@ -39,6 +39,7 @@ class ResnetModel(pl.LightningModule):
         num_classes=10,
         lr=0.05,
         weight_decay=0.0005,
+        momentum=0.9,
         batch_size=32,
         train_size=50000,
         channels=3,
@@ -52,6 +53,7 @@ class ResnetModel(pl.LightningModule):
             self.task = "multiclass"
         self.lr = lr
         self.weight_decay = weight_decay
+        self.momentum = self.momentum
         self.steps_per_epoch = train_size // batch_size
         self.optimizer = None
 
@@ -101,7 +103,7 @@ class ResnetModel(pl.LightningModule):
         self.optimizer = torch.optim.SGD(
             self.parameters(),
             lr=self.lr,
-            momentum=0.9,
+            momentum=self.momentum,
             weight_decay=self.weight_decay,
         )
         scheduler_dict = {


### PR DESCRIPTION
This PR has ended up becoming something of a catch-all for not only the training regime, but some general fixes and tweaking of the drop-only experiment group. The changes are:

- After reviewing some papers and following discussion in the stand-ups, it seems it's best to stick to a training regime similar to that in phase 1. The main reason is to allow us to train a large number of models in a relatively short time. The SOTA procedure for ResNet in one of the papers was a 600-epoch procedure, and a shorter 100-epoch procedure in the same paper took 100 hours even with GPU.
- That said, I've decreased the learning rate in line with one of the papers. This did seem to marginally improve things, but this was with two different seeds
- I've added an explicit momentum argument to our resnet model. Before this was set to 0.9 in the code
- Some arguments to the model (weight decay, momentum) are now explicitly set in the trainer config. No actual change to training regime here, but this is a more explicit approach
- A bug where run_B was the same run as run_A despite the correct arguments being passed has been fixed. It seems only one wandb run can be active at a time, so this is fixed by explicitly finishing reach run then re-initialising it in the attack script when it's time to log the results
- Some extra info on slurm in the scripts/README