### PR TITLE
Fix training

### DIFF
--- a/scripts/templates/slurm-attack-template.sh
+++ b/scripts/templates/slurm-attack-template.sh
@@ -6,7 +6,7 @@
 #SBATCH --gpus 1
 #SBATCH --cpus-per-gpu 36
 #SBATCH --job-name ms2-{{experiment_name}}-attack
-#SBATCH --output ./{{experiment_name}}_attack_logs/attck-%j.out
+#SBATCH --output ./slurm_attack_logs/{{experiment_name}}-attack-%j.out
 
 module purge
 module load baskerville

--- a/scripts/templates/slurm-attack-template.sh
+++ b/scripts/templates/slurm-attack-template.sh
@@ -6,7 +6,7 @@
 #SBATCH --gpus 1
 #SBATCH --cpus-per-gpu 36
 #SBATCH --job-name ms2-{{experiment_name}}-attack
-#SBATCH --output ./slurm_attack_logs/attck-%j.out
+#SBATCH --output ./{{experiment_name}}_attack_logs/attck-%j.out
 
 module purge
 module load baskerville

--- a/scripts/templates/slurm-train-template.sh
+++ b/scripts/templates/slurm-train-template.sh
@@ -6,7 +6,7 @@
 #SBATCH --gpus 1
 #SBATCH --cpus-per-gpu 36
 #SBATCH --job-name ms2-{{experiment_name}}
-#SBATCH --output ./{{experiment_name}}_train_logs/train-%j.out
+#SBATCH --output ./slurm_train_logs/{{experiment_name}}-train-%j.out
 
 module purge
 module load baskerville

--- a/scripts/templates/slurm-train-template.sh
+++ b/scripts/templates/slurm-train-template.sh
@@ -6,7 +6,7 @@
 #SBATCH --gpus 1
 #SBATCH --cpus-per-gpu 36
 #SBATCH --job-name ms2-{{experiment_name}}
-#SBATCH --output ./slurm_train_logs/train-%j.out
+#SBATCH --output ./{{experiment_name}}_train_logs/train-%j.out
 
 module purge
 module load baskerville

--- a/src/modsim2/model/resnet.py
+++ b/src/modsim2/model/resnet.py
@@ -1,5 +1,7 @@
 # Modified from mod sim phase 1 code
 
+import math
+
 import pytorch_lightning as pl
 import torch
 import torch.nn.functional as F
@@ -54,7 +56,7 @@ class ResnetModel(pl.LightningModule):
         self.lr = lr
         self.weight_decay = weight_decay
         self.momentum = momentum
-        self.steps_per_epoch = train_size // batch_size
+        self.steps_per_epoch = math.ceil(train_size / batch_size)
         self.optimizer = None
 
     def forward(self, x):


### PR DESCRIPTION
A quick PR that fixes some training issues:

- For some reason, when the data drop was 75% the training would fail on the 9th epoch. A small change to how the number of steps is calculated and rounded fixes this
- Some changes to the names of the logs so they're more informative