### PR TITLE
4 implement pad

### DIFF
--- a/scripts/train_models.py
+++ b/scripts/train_models.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import wandb
 import yaml
 from pytorch_lightning import LightningDataModule, Trainer
 from pytorch_lightning.callbacks import LearningRateMonitor
@@ -8,7 +9,6 @@ from pytorch_lightning.callbacks.progress import TQDMProgressBar
 from pytorch_lightning.utilities.seed import seed_everything
 from utils import opts2dmpairArgs
 
-import wandb
 from modsim2.data.loader import DMPair
 from modsim2.model.resnet import ResnetModel
 from modsim2.model.utils import run_exists

--- a/src/modsim2/similarity/metrics/mmd.py
+++ b/src/modsim2/similarity/metrics/mmd.py
@@ -72,8 +72,8 @@ class MMD(DistanceMetric):
         the future.
 
         Args:
-            array_A: The first image dataset
-            array_B: The second image dataset
+            data_A: The first image dataset
+            data_B: The second image dataset
             embedding_name: What feature embeddings, if any, to use for the
                             input arrays
             kernel_name: An appropriate kernel embedding. See kernel_dict

--- a/src/modsim2/similarity/metrics/otdd.py
+++ b/src/modsim2/similarity/metrics/otdd.py
@@ -48,8 +48,8 @@ class OTDD(DistanceMetric):
         Calculates the optimal transport dataset distance
 
         Args:
-            array_A: The first image dataset
-            array_B: The second image dataset
+            data_A: The first image dataset
+            data_B: The second image dataset
             max_samples (int):  maximum number of samples used in outer-level
                         otdd problem.
             device (str): the device on which the calculation will run,

--- a/src/modsim2/similarity/metrics/pad.py
+++ b/src/modsim2/similarity/metrics/pad.py
@@ -1,0 +1,246 @@
+import logging
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+
+# from sklearn import metrics
+from sklearn.svm import SVC
+from sklearn.utils import shuffle
+
+from modsim2.similarity.embeddings import EMBEDDING_FN_DICT
+
+from .metrics import DistanceMetric
+
+# Set module logger
+logger = logging.getLogger(__name__)
+
+
+class PAD(DistanceMetric):
+    """
+    Class to calculate the proxy a-distance between two datasets.
+    The metric combines the source and target (A and B) datasets.
+    The combined dataset is divided into train and test sets,
+    and classifier(s) are built using the train dataset to distinguish
+    between the source and target. The classifier(s) are then evaluated
+    using the test dataset and the lowest error across all the classifiers
+    is used to calculate the proxy a-distance:
+    pad = 2 * (1 - 2 * min_error)
+
+    In this implementation, Support Vector Machines are used as
+    the classifiers. The classifiers can be created with any of the
+    kernels allowed in sklearn's SVC, and the data can be transformed
+    with any of the embeddings available in this project. Multiple
+    classifiers may be created to allow for some hyperparameter tuning.
+
+    """
+
+    def __init__(self, seed: int):
+        super().__init__(seed)
+
+        self.__test_proportion = 0.2  # The % of the dataset to be held out for testing
+        self.__embedding_name = None  # Name of the embedding function
+        self.__train_data = None
+        self.__train_labels = None
+        self.__test_data = None
+        self.__test_labels = None
+        self.__embed_train_data = None
+        self.__embed_test_data = None
+        self.__models = []  # List of trained classifiers
+        self.__evaluations = (
+            []
+        )  # List of evaluations (error) of test data for each classifier
+
+    def get_test_labels(self) -> np.ndarray:
+        """
+        This method is required for one of the tests - not used in the calculation
+        of the metric
+
+        Returns
+            self.__test_labels - the labels for the test datasest (a combination of
+            both A & B data)
+        """
+        return self.__test_labels
+
+    def __train_test_split(
+        self,
+        data_A: np.ndarray,
+        data_B: np.ndarray,
+    ):
+        """
+        This method splits the two datasets data_A and data_B into train and test
+        samples. To calculate the PAD, there should be the same number of samples
+        from A & B in the test dataset. However, there may not be the same number
+        of samples in A & B. The following lines of code determine the size of the
+        test dataset for both A & B - the minimum proportion size of the two datasets
+        """
+
+        test_size_A = np.round(data_A.shape[0] * self.__test_proportion)
+        test_size_B = np.round(data_B.shape[0] * self.__test_proportion)
+        test_size = int(min(test_size_A, test_size_B))
+
+        train_A, test_A = train_test_split(data_A, test_size=test_size, shuffle=True)
+        train_B, test_B = train_test_split(data_B, test_size=test_size, shuffle=True)
+
+        return train_A, test_A, train_B, test_B
+
+    @staticmethod
+    def __label_data(data: np.ndarray, label_value: int) -> np.ndarray:
+        """
+        Takes an array of data and an integer label value. Returns
+        an array matching the first dimension of the array of data
+        """
+        labels = np.ones(data.shape[0])
+        labels *= label_value
+        return labels
+
+    def __concat_data(
+        self,
+        train_A: np.ndarray,
+        test_A: np.ndarray,
+        train_B: np.ndarray,
+        test_B: np.ndarray,
+    ):
+        """
+        This method will label the A and B train and tests datasets,
+        then concatenate the train and test data. The train data are
+        then shuffled.
+        The data from A will be labelled 1 and B will be labelled 0
+        The train and test data and labels are assigned to class attributes
+        """
+        # Create labels for A & B data
+        train_labels_A, test_labels_A = self.__label_data(
+            train_A, 1
+        ), self.__label_data(test_A, 1)
+        train_labels_B, test_labels_B = self.__label_data(
+            train_B, 0
+        ), self.__label_data(test_B, 0)
+
+        # Concatenate the A and B datasets into train and test
+        self.__train_data = np.concatenate((train_A, train_B), axis=0)
+        self.__train_labels = np.concatenate((train_labels_A, train_labels_B), axis=0)
+        self.__test_data = np.concatenate((test_A, test_B), axis=0)
+        self.__test_labels = np.concatenate((test_labels_A, test_labels_B), axis=0)
+        # Shuffle the train data
+        self.__train_data, self.__train_labels = shuffle(
+            self.__train_data, self.__train_labels
+        )
+
+    def __transform_data(self):
+        """
+        Method to transform the object's train and test data
+        using the object's embedding function
+        The transformed data are saved as attributes of the object
+        """
+        # Extract embedding callable
+        embedding_fn = EMBEDDING_FN_DICT[self.__embedding_name]
+        # Transform the train and test data using the embedding function
+        self.__embed_train_data = embedding_fn(self.__train_data)
+        self.__embed_test_data = embedding_fn(self.__test_data)
+
+    def _pre_process_data(self, data_A: np.ndarray, data_B: np.ndarray):
+        """
+        Takes A & B datasets as arguments and calls the methods to process
+        the data ahead of building the classifiers. First the data are split
+        into train and test datasets, then labelled and concatenated and then
+        transformed using the embedding function.
+        """
+        # Split A and B into train and test datasets
+        # This is done before the data are concatenated in order
+        # to ensure that the same proportion of A & B are
+        # included in the test dataset
+        train_A, test_A, train_B, test_B = self.__train_test_split(data_A, data_B)
+        # transform data - will depend on classifier type as to the transform
+
+        self.__concat_data(train_A, test_A, train_B, test_B)
+
+        self.__transform_data()
+
+    def __build_models(
+        self, kernel_name: str, c_values: list, gamma_values: list, degree_values: list
+    ):
+        """
+        This method will build the classifiers, variation in some hyperparameters
+        is allowed as the optimal values are not necessarily known for the datasets.
+        The kernel is not varied.
+        """
+        for c in c_values:
+            for gamma in gamma_values:
+                for degree in degree_values:
+                    svc = SVC(kernel=kernel_name, C=c, gamma=gamma, degree=degree)
+                    svc.fit(X=self.__embed_train_data, y=self.__train_labels)
+                    self.__models.append(svc)
+
+    def __evaluate_models(self):
+        """
+        This method will evaluate the classifiers that have been built
+        The evaluation metric is the mean absolute error.
+        """
+        for svc in self.__models:
+            preds = svc.predict(self.__embed_test_data)
+            errors = np.abs(preds - self.__test_labels)
+            error = np.sum(errors) / len(preds)
+            self.__evaluations.append(error)
+
+    def calculate_distance(
+        self,
+        data_A: np.ndarray,
+        data_B: np.ndarray,
+        labels_A: np.ndarray,
+        labels_B: np.ndarray,
+        c_values: list,
+        kernel_name: str,
+        embedding_name: str,
+        test_proportion: float,
+        distinct_classes: bool = False,
+        gamma_values: list = ["scale"],
+        degree_values: list = [3],
+    ) -> float:
+
+        """
+        Calculates the proxy a-distance for datasets A and B.
+        As this implementation uses SVM, the attributes include
+        some parameters in sklearn's implementation of SVC. A
+        single value for the kernel name is accepted, and a list
+        of possible C values (to allow for some hyperparameter tuning).
+        Optional attributes that can be included in the kwargs
+        are a list of gamma values and degree values. If these aren't
+        provided then they will be set to default values.
+        """
+
+        # Set the variables required for the pre-processing
+        assert embedding_name in EMBEDDING_FN_DICT, "Error: embedding does not exist"
+        self.__embedding_name = embedding_name
+
+        assert (
+            test_proportion < 1 and test_proportion > 0
+        ), "The test_proportion value must be between zero and one"
+        self.__test_proportion = test_proportion
+
+        if distinct_classes:
+            data_A, data_B = self._divide_by_class(data_A, labels_A, data_B, labels_B)
+
+        # Pre-process the data
+        self._pre_process_data(data_A, data_B)
+
+        # Build the classifiers
+        self.__build_models(kernel_name, c_values, gamma_values, degree_values)
+
+        # Evaluate classifiers
+        self.__evaluate_models()
+
+        # Compute the proxy a-distance
+        min_error = min(self.__evaluations)
+        pad = 2 * (1 - 2 * min_error)
+
+        return pad
+
+    @staticmethod
+    def _divide_by_class(data_A, labels_A, data_B, labels_B):
+        all_labels = np.concatenate([np.array(labels_A), np.array(labels_B)])
+        unique_classes = np.unique(all_labels)
+        np.random.shuffle(unique_classes)
+        num_classes_A = int(round(len(unique_classes) / 2, 0))
+        classes_A = np.isin(labels_A, unique_classes[:num_classes_A])
+        classes_B = np.isin(labels_B, unique_classes[num_classes_A:])
+
+        return data_A[classes_A], data_B[classes_B]

--- a/src/modsim2/similarity/metrics/pad.py
+++ b/src/modsim2/similarity/metrics/pad.py
@@ -46,9 +46,7 @@ class PAD(DistanceMetric):
         self.__embed_train_data = None
         self.__embed_test_data = None
         self.__models = []  # List of trained classifiers
-        self.__evaluations = (
-            []
-        )  # List of evaluations (error) of test data for each classifier
+        self.__errors = []  # List of errors for classifiers on test data
 
     def get_test_labels(self) -> np.ndarray:
         """
@@ -72,12 +70,22 @@ class PAD(DistanceMetric):
         from A & B in the test dataset. However, there may not be the same number
         of samples in A & B. The following lines of code determine the size of the
         test dataset for both A & B - the minimum proportion size of the two datasets
-        """
 
+        Args:
+            data_A: all records in dataset A (excludes target value)
+            data_B: all records in dataset B (excludes target value)
+
+        Returns:
+            train_A: records in dataset A to be used for training
+            test_A: records in dataset A to be used for testing (final evaluation)
+            train_B: records in dataset B to be used for training
+            test_B: records in dataset B to be used for testing (final evaluation)
+        """
+        # Determine the number of samples of test data to be drawn from A&B
         test_size_A = np.round(data_A.shape[0] * self.__test_proportion)
         test_size_B = np.round(data_B.shape[0] * self.__test_proportion)
         test_size = int(min(test_size_A, test_size_B))
-
+        # Split A&B into train and test
         train_A, test_A = train_test_split(data_A, test_size=test_size, shuffle=True)
         train_B, test_B = train_test_split(data_B, test_size=test_size, shuffle=True)
 
@@ -87,7 +95,16 @@ class PAD(DistanceMetric):
     def __label_data(data: np.ndarray, label_value: int) -> np.ndarray:
         """
         Takes an array of data and an integer label value. Returns
-        an array matching the first dimension of the array of data
+        an array of the label value with length matching the first
+        dimension of the array of data
+
+        Args:
+            data: array of data (any dimension)
+            label_value: integer value to set the label data
+
+        Returns:
+            labels: array of value label_value with length matching
+                    the number of data records
         """
         labels = np.ones(data.shape[0])
         labels *= label_value
@@ -106,6 +123,12 @@ class PAD(DistanceMetric):
         then shuffled.
         The data from A will be labelled 1 and B will be labelled 0
         The train and test data and labels are assigned to class attributes
+
+        Args:
+            train_A: the data for training from dataset A
+            test_A: the data for testing from dataset A
+            train_B: the data for training from dataset B
+            test_B: the data for testing from dataset B
         """
         # Create labels for A & B data
         train_labels_A, test_labels_A = self.__label_data(
@@ -129,7 +152,7 @@ class PAD(DistanceMetric):
         """
         Method to transform the object's train and test data
         using the object's embedding function
-        The transformed data are saved as attributes of the object
+        The transformed data are assigned to attributes of the object
         """
         # Extract embedding callable
         embedding_fn = EMBEDDING_FN_DICT[self.__embedding_name]
@@ -143,6 +166,10 @@ class PAD(DistanceMetric):
         the data ahead of building the classifiers. First the data are split
         into train and test datasets, then labelled and concatenated and then
         transformed using the embedding function.
+
+        Args:
+            data_A: the records in the A dataset (excludes target values)
+            data_B: the records in the B dataset (excludes target values)
         """
         # Split A and B into train and test datasets
         # This is done before the data are concatenated in order
@@ -162,6 +189,13 @@ class PAD(DistanceMetric):
         This method will build the classifiers, variation in some hyperparameters
         is allowed as the optimal values are not necessarily known for the datasets.
         The kernel is not varied.
+        The trained model are appended to the object's list of models.
+
+        Args:
+            kernel_name:
+            c_values: list of C values (regularisation param) to be applied
+            gamma_values: list of gamma values (kernel coefficient) to be applied
+            degree_values: list of degree values for the poly kernel to be applied
         """
         for c in c_values:
             for gamma in gamma_values:
@@ -179,7 +213,7 @@ class PAD(DistanceMetric):
             preds = svc.predict(self.__embed_test_data)
             errors = np.abs(preds - self.__test_labels)
             error = np.sum(errors) / len(preds)
-            self.__evaluations.append(error)
+            self.__errors.append(error)
 
     def calculate_distance(
         self,
@@ -191,20 +225,38 @@ class PAD(DistanceMetric):
         kernel_name: str,
         embedding_name: str,
         test_proportion: float,
-        distinct_classes: bool = False,
         gamma_values: list = ["scale"],
         degree_values: list = [3],
+        distinct_classes: bool = False,
     ) -> float:
 
         """
         Calculates the proxy a-distance for datasets A and B.
         As this implementation uses SVM, the attributes include
         some parameters in sklearn's implementation of SVC. A
-        single value for the kernel name is accepted, and a list
-        of possible C values (to allow for some hyperparameter tuning).
-        Optional attributes that can be included in the kwargs
-        are a list of gamma values and degree values. If these aren't
-        provided then they will be set to default values.
+        single value for the kernel name is accepted, and lists
+        of possible C values, gamma values and degree values
+        (to allow for some hyperparameter tuning).
+
+        Defaults are provided for the gamma and degree values
+        meaning these do not have to be supplied in the metrics
+        config.
+
+        Args:
+            data_A: The first image dataset
+            data_B: The second image dataset
+            labels_A: The target values for the first dataset
+            labels_B: The target values for the second dataset
+            c_values: List of C values (regularisation param) to be applied
+                      in the SVCs
+            kernel_name: The kernel to be applied in the SVCs
+            embedding_name: What feature embeddings, if any, to use for the
+                            input arrays
+            test_proportion: the proportion of the dataset to hold out for testing
+            gamma_values: list of gamma values to be applied in SVCs
+            degree_values: list of degree values to be applied in polynomial SVCs
+            distinct_classes: only used during testing - drops records in A & B to
+                              so that they have distinct classes
         """
 
         # Set the variables required for the pre-processing
@@ -235,12 +287,36 @@ class PAD(DistanceMetric):
         return pad
 
     @staticmethod
-    def _divide_by_class(data_A, labels_A, data_B, labels_B):
+    def _divide_by_class(
+        data_A: np.ndarray,
+        labels_A: np.ndarray,
+        data_B: np.ndarray,
+        labels_B: np.ndarray,
+    ):
+        """
+        This method is only used during testing to create two datasets
+        with distinct classes in their target values.
+        Takes data records A & B and corresponding arraysof labels.
+        It identifies the unique values (classes) across both label arrays.
+        Half the classes are randomly selected to be applied in dataset A
+        and half in dataset B, the data records are then filtered accordingly.
+
+        Args:
+            data_A: The first image dataset
+            data_B: The second image dataset
+            labels_A: The target values for the first dataset
+            labels_B: The target values for the second dataset
+
+        Returns:
+            subset_data_A: The first dataset filtered by half of the target values
+            subset_data_B: The second dataset filtered by (the other) half of the target
+                           values
+        """
         all_labels = np.concatenate([np.array(labels_A), np.array(labels_B)])
         unique_classes = np.unique(all_labels)
         np.random.shuffle(unique_classes)
         num_classes_A = int(round(len(unique_classes) / 2, 0))
         classes_A = np.isin(labels_A, unique_classes[:num_classes_A])
         classes_B = np.isin(labels_B, unique_classes[num_classes_A:])
-
-        return data_A[classes_A], data_B[classes_B]
+        subset_data_A, subset_data_B = data_A[classes_A], data_B[classes_B]
+        return subset_data_A, subset_data_B

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -74,7 +74,7 @@ def test_cifar_pad_distinct(metrics_config: dict):
 
 # This test checks that there are equal samples of A and B in the
 # combined test dataset
-def test_equal_samples(metrics_config: dict):
+def test_cifar_pad_equal_samples(metrics_config: dict):
     dmpair = DMPair(metrics_config=metrics_config)
     train_data_A, val_data_A = dmpair.get_A_data()
     train_data_B, val_data_B = dmpair.get_B_data()
@@ -98,7 +98,10 @@ def test_equal_samples(metrics_config: dict):
         sum_test_labels = np.sum(combined_test_labels)
         count_test_labels = combined_test_labels.shape[0]
 
-        assert 2 * sum_test_labels == count_test_labels
+        # The label values are either zero or one, so the
+        # sum of the labels should equal half the number
+        # of records
+        assert (2 * sum_test_labels) == count_test_labels
 
 
 # This function takes the computed distances (stored in test_scenarios) and

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -1,0 +1,121 @@
+import copy
+import os
+
+import numpy as np
+import pytest
+import yaml
+from pytest_check import check
+
+from modsim2.data.loader import DMPair
+from modsim2.similarity.metrics import pad
+
+
+# Fixture that returns the metric config dictionary
+@pytest.fixture(scope="module")
+def metrics_config() -> dict:
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    metrics_config_path = os.path.join(
+        project_root, "tests", "testconfig", "metrics.yaml"
+    )
+    with open(metrics_config_path, "r") as stream:
+        pad_config = yaml.safe_load(stream)
+    # filter down to only pad configs
+    pad_config = {k: v for k, v in pad_config.items() if v["class"] == "pad"}
+    return pad_config
+
+
+# This test checks that the distance between a dataset and itself is the expect value
+# For this metric the expected value is always zero
+def test_cifar_pad_same(metrics_config: dict):
+    dmpair = DMPair(metrics_config=metrics_config)
+    similarity_dict = dmpair.compute_similarity()
+    similarity_dict_only_train = dmpair.compute_similarity(only_train=True)
+    test_scenarios = {
+        "same_result": similarity_dict,
+        "same_result_only_train": similarity_dict_only_train,
+    }
+    compare_results(test_scenarios, metrics_config)
+
+
+# This test checks that the distance between two different datasets is the expected
+# value
+# The calculated distance is checked against the known value for the seed - brittle
+# test but useful for messing with code
+def test_cifar_pad_different(metrics_config: dict):
+    dmpair = DMPair(metrics_config=metrics_config, drop_percent_A=0.2, seed=42)
+    similarity_dict = dmpair.compute_similarity()
+    similarity_dict_only_train = dmpair.compute_similarity(only_train=True)
+    test_scenarios = {
+        "diff_result": similarity_dict,
+        "diff_result_only_train": similarity_dict_only_train,
+    }
+    compare_results(test_scenarios, metrics_config)
+
+
+# This test checks that the distance between two datasets with distinct labels
+# has a greater pad than when the datasets are the same. This is a sanity check
+# to ensure that the classifier(s) used in the pad calculation better at
+# distinguishing between two datasets that have different labels compared
+# to when the two datasets have the same labels.
+def test_cifar_pad_distinct(metrics_config: dict):
+
+    dmpair = DMPair(metrics_config=metrics_config)
+    similarity_dict = dmpair.compute_similarity()
+
+    metrics_config_copy = copy.deepcopy(metrics_config)
+    for k in metrics_config_copy:
+        metrics_config_copy[k]["arguments"]["distinct_classes"] = True
+    dmpair_distinct_classes = DMPair(metrics_config=metrics_config_copy)
+    similarity_dict_distinct_classes = dmpair_distinct_classes.compute_similarity()
+
+    for k in metrics_config:
+        assert similarity_dict[k] < similarity_dict_distinct_classes[k]
+
+
+# This test checks that there are equal samples of A and B in the
+# combined test dataset
+def test_equal_samples(metrics_config: dict):
+    dmpair = DMPair(metrics_config=metrics_config)
+    train_data_A, val_data_A = dmpair.get_A_data()
+    train_data_B, val_data_B = dmpair.get_B_data()
+
+    train_labels_A, val_labels_A = dmpair.get_A_labels()
+    train_labels_B, val_labels_B = dmpair.get_B_labels()
+
+    data_A = np.concatenate((train_data_A, val_data_A), axis=0)
+    data_B = np.concatenate((train_data_B, val_data_B), axis=0)
+
+    labels_A = np.concatenate((train_labels_A, val_labels_A), axis=0)
+    labels_B = np.concatenate((train_labels_B, val_labels_B), axis=0)
+    for _, metric in metrics_config.items():
+
+        metric_conf = pad.PAD(seed=42)
+
+        _ = metric_conf.calculate_distance(
+            data_A, data_B, labels_A, labels_B, **metric["arguments"]
+        )
+        combined_test_labels = metric_conf.get_test_labels()
+        sum_test_labels = np.sum(combined_test_labels)
+        count_test_labels = combined_test_labels.shape[0]
+
+        assert 2 * sum_test_labels == count_test_labels
+
+
+# This function takes the computed distances (stored in test_scenarios) and
+# compares them to the expected distances (stored in metrics_config)
+def compare_results(test_scenarios: dict, metrics_config: dict):
+    for scenario, results in test_scenarios.items():
+        for k in metrics_config:
+            expected_result = metrics_config[k]["expected_results"][scenario]
+            actual_result = results[k]
+            with check:
+                assert actual_result == expected_result, (
+                    "test:"
+                    + k
+                    + "/"
+                    + scenario
+                    + ", expected result: "
+                    + str(expected_result)
+                    + ", actual result: "
+                    + str(actual_result)
+                )

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -52,24 +52,29 @@ def test_cifar_pad_different(metrics_config: dict):
     compare_results(test_scenarios, metrics_config)
 
 
-# This test checks that the distance between two datasets with distinct labels
-# has a greater pad than when the datasets are the same. This is a sanity check
-# to ensure that the classifier(s) used in the pad calculation better at
-# distinguishing between two datasets that have different labels compared
-# to when the two datasets have the same labels.
+# This test is a sanity check that ensures the PAD between two datasets
+# with distinct labels is greater than when the datasets labels contain
+# the same classes. In theory the classifiers should be more able to
+# distinguish between the two datasets if their classes are distinct.
 def test_cifar_pad_distinct(metrics_config: dict):
 
     dmpair = DMPair(metrics_config=metrics_config)
     similarity_dict = dmpair.compute_similarity()
 
+    dmpair = DMPair(
+        metrics_config=metrics_config, drop_percent_A=0.5, drop_percent_B=0.5, seed=42
+    )
+    similarity_dict_diff = dmpair.compute_similarity()
+
     metrics_config_copy = copy.deepcopy(metrics_config)
     for k in metrics_config_copy:
         metrics_config_copy[k]["arguments"]["distinct_classes"] = True
-    dmpair_distinct_classes = DMPair(metrics_config=metrics_config_copy)
-    similarity_dict_distinct_classes = dmpair_distinct_classes.compute_similarity()
+    dmpair = DMPair(metrics_config=metrics_config_copy)
+    similarity_dict_distinct_classes = dmpair.compute_similarity()
 
     for k in metrics_config:
         assert similarity_dict[k] < similarity_dict_distinct_classes[k]
+        assert similarity_dict_diff[k] < similarity_dict_distinct_classes[k]
 
 
 # This test checks that there are equal samples of A and B in the


### PR DESCRIPTION
The main features of the PR are:
- Introduction of a new metric Proxy A-Distance (PAD) in a script `pad.py`
- Introduction of a new test file for the metric: `test_pad.py`

Comments on the implementation:
- As discussed, the PAD has been implemented using only SVMs for the classifier
- I have followed the implementation in one of the papers that allows for multiple SVMs to be built for each calculation of PAD. The rational for this is that some hyperparameter tuning may be required to determine the classifier that can produce the lowest error. 
- I’m not an expert on SVMs and I don’t know if it would make sense to include additional hyperparameters to the ones I have included already.
- To measure the error of the classifier, the MAE has been used which measures the error between the prediction and the target values - the error is measured on the test data only
- I have assumed for the PAD to be meaningful, there need to be the same number of samples from A&B in the test dataset
- I have not created any new embeddings and assume this will get covered in issue #21 

Comments on metric:
- By my reckoning, the PAD can be in the range [-2, 2] (though this is different to what is stated in other repo on the topic [https://github.com/rpryzant/proxy-a-distance](https://github.com/rpryzant/proxy-a-distance))
- If A&B are **dissimilar**, then the classifier(s) should be able to distinguish between them leading to a low error and a **high PAD**
- If A&B are **similar**, then the classifier(s) will struggle to distinguish between them leading to a high error and a l**ow PAD**

Comments on testing:

- I’ve created two additional tests compared to the other metrics, I used these during the development and I’m not sure if they are worth keeping or not. I'm not particularly satisfied with the code for either, but struggled thinking of neater ways to implement them. 
- `test_cifar_pad_equal_samples` is just confirming that there are the same number of records in the test dataset from A&B (on the assumption that the calculation would be less meaningful if this didn’t occur). 
- `test_cifar_pad_distinct` is more of a sanity check to see how the PAD behaves, it drops data from A&B so that they have distinct classes in their target values creating two datasets that are dissimilar without applying any transforms. I wanted to check that the PAD for datasets with distinct classes would be higher than if A&B contain the same classes. Dropping the data would make more sense to occur in the DMPair class, but I am not sure this will be required beyond PAD testing so I included it in the PAD class. It could be removed altogether, though I did find it useful to check the classifiers are doing what you expect them to! Might also be a useful test to keep if we include alternative embeddings and hyper parameters in future.  
