### PR TITLE
61 attack metrics

### DIFF
--- a/scripts/attack.py
+++ b/scripts/attack.py
@@ -200,10 +200,10 @@ def main(
         project_name=project_name,
     )
     run_B.log({"B_to_A_metrics": B_to_A_metrics}, commit=True)
-    run_A.log(vulnerability_AB_fga, commit=True)
-    run_A.log(vulnerability_BB_fga, commit=True)
-    run_A.log(vulnerability_AB_boundary, commit=True)
-    run_A.log(vulnerability_BB_boundary, commit=True)
+    run_B.log(vulnerability_AB_fga, commit=True)
+    run_B.log(vulnerability_BB_fga, commit=True)
+    run_B.log(vulnerability_AB_boundary, commit=True)
+    run_B.log(vulnerability_BB_boundary, commit=True)
     run_B.finish()
 
 

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -16,10 +16,6 @@ def select_best_attack(
     the first successful attack with the smallest possible value of epsilon. If no
     image is sucessful, it will select the image with the highest epsilon value.
 
-    Returns: a torch.tensor containing the adversarial images and a torch.tensor
-             where each element corresponds to an adversarial image and denotes
-             whether that image sucessfully attacks the network
-
     Args:
         images: A list of torch.tensors of length num_epsilon. Each tensor contains
                 the adversarial images generated for the corresponding value of
@@ -28,6 +24,10 @@ def select_best_attack(
                  False values denoting whether the corresponding image in images is
                  successfully adversarial
         epsilons: A list of values of epsilon used to generate the list of images
+
+    Returns: a torch.tensor containing the adversarial images and a torch.tensor
+             where each element represents the percentage of successful attacks at
+             each value of epsilon
     """
     # Sort into order from lowest to highest epsilon to allow arbitary input order
     num_epsilon = len(epsilons)
@@ -72,7 +72,9 @@ def generate_adversarial_images(
         device: String passed to fb.PyTorchModel for computation
         **kwargs: Additional arguments based to attack setup
 
-    Returns: a torch.tensor containing the adversarial images
+    Returns: a torch.tensor containing the adversarial images and a torch.tensor
+             where each element represents the percentage of successful attacks at
+             each value of epsilon
     """
     # Check for valid attack choices
     if attack_fn_name not in ["L2FastGradientAttack", "BoundaryAttack"]:

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -40,10 +40,15 @@ def select_best_attack(
     advs_images = []
     advs_success = torch.zeros(num_epsilon, device=success.device)
     num_attack_images = len(images[0])
+    # For every image and value of epsilon
     for i in range(num_attack_images):
         for j in range(num_epsilon):
+            # If the image is sucessful or is the last image, append it to the
+            # output adversarial images
             if success[j][i] or j == (num_epsilon - 1):
                 advs_images.append(images[j][i])
+                # += success instead of 1 so last image doesn't automatically add
+                # to success
                 advs_success[j:] += success[j][i]
                 break
     return torch.stack((advs_images)), advs_success / num_attack_images
@@ -149,7 +154,8 @@ def generate_over_combinations(
     """
     # Make dict of adversarial images
     # 4 elements, w/ keys like model_A_dist_A
-    # Each element is a torch.tensor containing adversarial images
+    # Each element is a torch.tensor containing adversarial images and a
+    # torch.tensor with success rates at each value of epsilon
     adversarial_images_dict = {}
     for model, model_name in tqdm([(model_A, "model_A"), (model_B, "model_B")]):
         for images, labels, distribution_name in tqdm(

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -38,15 +38,15 @@ def select_best_attack(
 
     # Best attack selection loop
     advs_images = []
-    advs_success = []
+    advs_success = torch.zeros(num_epsilon, device=success.device)
     num_attack_images = len(images[0])
     for i in range(num_attack_images):
         for j in range(num_epsilon):
             if success[j][i] or j == (num_epsilon - 1):
                 advs_images.append(images[j][i])
-                advs_success.append(success[j][i])
+                advs_success[j:] += success[j][i]
                 break
-    return torch.stack((advs_images)), torch.stack(advs_success)
+    return torch.stack((advs_images)), advs_success / num_attack_images
 
 
 def generate_adversarial_images(

--- a/tests/test_adversarial_images.py
+++ b/tests/test_adversarial_images.py
@@ -26,7 +26,9 @@ def test_best_attack_selection():
 
     # this means the best selection function should *always* select the
     # second image in the list (as this corresponds to the lowest epsilon 0.3
-    # that is still success)
-    best_images = select_best_attack(images=images, success=success, epsilons=epsilons)
+    # that is still successful)
+    best_images, _ = select_best_attack(
+        images=images, success=success, epsilons=epsilons
+    )
     assert_equal = functools.partial(torch.testing.assert_close, rtol=0, atol=0)
     assert_equal(images[1], best_images)

--- a/tests/test_adversarial_images.py
+++ b/tests/test_adversarial_images.py
@@ -27,8 +27,14 @@ def test_best_attack_selection():
     # this means the best selection function should *always* select the
     # second image in the list (as this corresponds to the lowest epsilon 0.3
     # that is still successful)
-    best_images, _ = select_best_attack(
+    best_images, success_rates = select_best_attack(
         images=images, success=success, epsilons=epsilons
     )
+
+    # Check that second image is always chosen
     assert_equal = functools.partial(torch.testing.assert_close, rtol=0, atol=0)
     assert_equal(images[1], best_images)
+
+    # Success rates should be 0, 1, 1, 1 (as fn will sort to this order and all
+    # from second image onwards are successful)
+    assert_equal(success_rates, torch.tensor([0.0, 1.0, 1.0, 1.0]))


### PR DESCRIPTION
This PR resolves #61. It adds logging of baseline model vulnerabilities:

- Each model has 4 statistics associated with it
- 2 for images drawn from models A and B
- 2 for each of the two attacks

It also updates the test for image selection to reflect the change in function output.