### PR TITLE
54 pad params

### DIFF
--- a/configs/metrics/pad.yaml
+++ b/configs/metrics/pad.yaml
@@ -1,4 +1,4 @@
-baskerville: False
+baskerville: True
 metrics:
   pad_linear:
     class: pad
@@ -8,10 +8,15 @@ metrics:
         - 0.1
         - 1
         - 10
-      embedding_name: matrix
+      embedding_name: inception_umap
+      embedding_kwargs:
+        batch_size: 16
+        device: cpu
+        n_components: 2
+        random_seed: 42
       test_proportion: 0.2
-      balance_train: False
-      balance_test: False
+      balance_train: True
+      balance_test: True
   pad_rbf:
     class: pad
     arguments:
@@ -23,22 +28,12 @@ metrics:
       gamma_values:
         - 'scale'
         - 'auto'
-      embedding_name: matrix
-      test_proportion: 0.2
-      balance_train: False
-      balance_test: True
-  pad_poly:
-    class: pad
-    arguments:
-      kernel_name: poly
-      c_values:
-        - 0.1
-        - 1
-        - 10
-      degree_values:
-        - 3
-        - 5
-      embedding_name: matrix
+      embedding_name: inception_umap
+      embedding_kwargs:
+        batch_size: 16
+        device: cpu
+        n_components: 2
+        random_seed: 42
       test_proportion: 0.2
       balance_train: True
-      balance_test: False
+      balance_test: True

--- a/configs/metrics/pad.yaml
+++ b/configs/metrics/pad.yaml
@@ -11,7 +11,7 @@ metrics:
       embedding_name: inception_umap
       embedding_kwargs:
         batch_size: 16
-        device: cpu
+        device: cuda
         n_components: 2
         random_seed: 42
       test_proportion: 0.2
@@ -31,7 +31,7 @@ metrics:
       embedding_name: inception_umap
       embedding_kwargs:
         batch_size: 16
-        device: cpu
+        device: cuda
         n_components: 2
         random_seed: 42
       test_proportion: 0.2

--- a/configs/metrics/pad.yaml
+++ b/configs/metrics/pad.yaml
@@ -1,6 +1,6 @@
 baskerville: True
 metrics:
-  pad_linear:
+  pad_linear_umap:
     class: pad
     arguments:
       kernel_name: linear
@@ -17,7 +17,7 @@ metrics:
       test_proportion: 0.2
       balance_train: True
       balance_test: True
-  pad_rbf:
+  pad_rbf_umap:
     class: pad
     arguments:
       kernel_name: rbf
@@ -33,6 +33,39 @@ metrics:
         batch_size: 16
         device: cuda
         n_components: 2
+        random_seed: 42
+      test_proportion: 0.2
+      balance_train: True
+      balance_test: True
+  pad_linear_pca:
+    class: pad
+    arguments:
+      kernel_name: linear
+      c_values:
+        - 0.1
+      embedding_name: inception_pca
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+        n_components: 50
+        random_seed: 42
+      test_proportion: 0.2
+      balance_train: True
+      balance_test: True
+  pad_rbf_pca:
+    class: pad
+    arguments:
+      kernel_name: rbf
+      c_values:
+        - 0.1
+      gamma_values:
+        - 'scale'
+        - 'auto'
+      embedding_name: inception_pca
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+        n_components: 50
         random_seed: 42
       test_proportion: 0.2
       balance_train: True

--- a/src/modsim2/similarity/metrics/pad.py
+++ b/src/modsim2/similarity/metrics/pad.py
@@ -46,8 +46,7 @@ class PAD(DistanceMetric):
         This method splits the two datasets data_A and data_B into train and test
         samples. To calculate the PAD, there should be the same number of samples
         from A & B in the test dataset. However, there may not be the same number
-        of samples in A & B. The following lines of code determine the size of the
-        test dataset for both A & B - the minimum proportion size of the two datasets
+        of samples in A & B.
 
         Args:
             data_A: all records in dataset A (excludes target value)
@@ -121,7 +120,8 @@ class PAD(DistanceMetric):
                       be reduced to
 
         Returns:
-            reduced_array:
+            reduced_array: the numpy array with a random selection of
+                    row removed to leave new_size records
         """
         random_indices = np.random.choice(
             array_to_reduce.shape[0], new_size, replace=False
@@ -198,7 +198,6 @@ class PAD(DistanceMetric):
                           from A and B in the test dataset
             embedding_name: What feature embeddings, if any, to use for the
                             input arrays
-
             embedding_kwargs: Dict of arguments to pass to the embedding function
 
         Returns:
@@ -336,7 +335,8 @@ class PAD(DistanceMetric):
             balance_train: Determines whether to balance the number of observations
                            from A and B in the training dataset
             balance_test: Determines whether to balance the number of observations
-                          from A and B in the test dataset
+                          from A and B in the test dataset, must be set to True to
+                          calculate the PAD
             gamma_values: List of gamma values to be applied in SVCs, see sklearn
                             documentation for list of possible values
             degree_values: List of degree values to be applied in polynomial SVCs


### PR DESCRIPTION
This PR updates the parameters in the config file for Proxy A-Distance (PAD). I've updated a few of the comments in the PAD file. 

Some comments on the parameter selection:
- `balance_test` should always be set to `True` otherwise we are not calculating the PAD (not sure it makes sense for this to be an option in the config)
- The evaluation on the test dataset was better when `balance_train` was also set to `True`
- I have dropped the polynomial kernel as it was very slow to run compared to the linear and rbf kernels
- The Inception + PCA embedding didn't appear to be effective at providing a representation of the datasets that a classifier could distinguish between - so I have not used this
- The Inception + UMAP embedding was effective, and the resulting PAD calculation was quick to calculate
- The classifier could also produce sensible results when using the matrix embedding; however, it would take hours to run my laptop. If we did want to run with the matrix embedding, then it would probably be best to limit the value of C = 0.1
- I started running the metric on the inception embedding only (without UMAP or PCA) this morning, but gave up after it was running for hours - if this is important then I can set it running overnight sometime. 

