### PR TITLE
New configs

### DIFF
--- a/configs/metrics/mmd_embed.yaml
+++ b/configs/metrics/mmd_embed.yaml
@@ -1,0 +1,21 @@
+baskerville: True
+metrics:
+  mmd_rbf_umap:
+    class: mmd
+    arguments:
+      kernel_name: rbf
+      embedding_name: inception_umap
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+        n_components: 2
+        random_seed: 42
+  mmd_rbf_pca:
+    class: mmd
+    arguments:
+      kernel_name: rbf
+      embedding_name: inception_pca
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+        n_components: 50

--- a/configs/metrics/mmd_raw.yaml
+++ b/configs/metrics/mmd_raw.yaml
@@ -1,6 +1,6 @@
 baskerville: False
 metrics:
-  mmd_rbf:
+  mmd_rbf_raw:
     class: mmd
     arguments:
       embedding_name: matrix

--- a/configs/metrics/otdd.yaml
+++ b/configs/metrics/otdd.yaml
@@ -1,8 +1,123 @@
 baskerville: True
 metrics:
-  otdd_exact:
+  otdd_exact_raw:
     class: otdd
     arguments:
+      # Arguments used here are defaults unless otherwise specified. Please
+      # see the source code for a description of what each parameter is:
+      # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L67
+      # general arguments
+      method: precomputed_labeldist
+      symmetric_tasks: False
+      feature_cost: euclidean
+      src_embedding: null
+      tgt_embedding: null
+      ignore_source_labels: False
+      ignore_target_labels: False
+
+      # Outer OT (dataset to dataset) problem arguments
+      loss: sinkhorn
+      debiased_loss: True
+      p: 2
+      entreg: 0.1
+      λ_x: 1.0
+      λ_y: 1.0
+
+      ## Inner OT (label to label) problem arguments
+      inner_ot_method: exact #changed from gaussian_approx
+      inner_ot_loss: sinkhorn
+      inner_ot_debiased: True #changed from False
+      inner_ot_p: 2
+      inner_ot_entreg: 0.1
+
+      # Gaussian Approximation Args
+      diagonal_cov: False
+      min_labelcount: 2
+      online_stats: True
+      sqrt_method: spectral
+      sqrt_niters: 20
+      sqrt_pref: 0
+      nworkers_stats: 0
+
+      # Misc
+      coupling_method: geomloss
+      nworkers_dists: 0
+      eigen_correction: False
+      device: cuda #changed from CPU
+      precision: single
+      verbose: 1
+
+      # dist.distance() args
+      # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L622
+      max_samples: 10000
+  otdd_exact_umap:
+    class: otdd
+    arguments:
+      # Data embedding:
+      embedding_name: inception_umap
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+        n_components: 2
+        random_seed: 42
+
+      # Arguments used here are defaults unless otherwise specified. Please
+      # see the source code for a description of what each parameter is:
+      # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L67
+      # general arguments
+      method: precomputed_labeldist
+      symmetric_tasks: False
+      feature_cost: euclidean
+      src_embedding: null
+      tgt_embedding: null
+      ignore_source_labels: False
+      ignore_target_labels: False
+
+      # Outer OT (dataset to dataset) problem arguments
+      loss: sinkhorn
+      debiased_loss: True
+      p: 2
+      entreg: 0.1
+      λ_x: 1.0
+      λ_y: 1.0
+
+      ## Inner OT (label to label) problem arguments
+      inner_ot_method: exact #changed from gaussian_approx
+      inner_ot_loss: sinkhorn
+      inner_ot_debiased: True #changed from False
+      inner_ot_p: 2
+      inner_ot_entreg: 0.1
+
+      # Gaussian Approximation Args
+      diagonal_cov: False
+      min_labelcount: 2
+      online_stats: True
+      sqrt_method: spectral
+      sqrt_niters: 20
+      sqrt_pref: 0
+      nworkers_stats: 0
+
+      # Misc
+      coupling_method: geomloss
+      nworkers_dists: 0
+      eigen_correction: False
+      device: cuda #changed from CPU
+      precision: single
+      verbose: 1
+
+      # dist.distance() args
+      # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L622
+      max_samples: 10000
+  otdd_exact_pca:
+    class: otdd
+    arguments:
+      # Data embedding:
+      embedding_name: inception_pca
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+        n_components: 50
+
       # Arguments used here are defaults unless otherwise specified. Please
       # see the source code for a description of what each parameter is:
       # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L67


### PR DESCRIPTION
This PR adds/updates configs so that our earlier metrics also use embeddings:

- mmd.yaml renamed to mmd_raw.yaml
- a new mmd_embed.yaml file for MMD with inception + UMAP and inception + PCA to be run on Baskerville
- OTDD with inception + UMAP and inception + PCA added to otdd.yaml

