### PR TITLE
Boundary init

### DIFF
--- a/configs/experiment_groups/rotate-180.yaml
+++ b/configs/experiment_groups/rotate-180.yaml
@@ -1,6 +1,6 @@
 define:
   - &none null
-  - &little-blur
+  - &rotate-180
     - name: RandomVerticalFlip
       kwargs:
         p: 1
@@ -12,39 +12,39 @@ dmpairs:
     transforms: *none
   B:
     drop: 0.0
-    transforms: *little-blur
+    transforms: *rotate-180
 
 - A:
     drop: 0.0
     transforms: *none
   B:
     drop: 0.5
-    transforms: *little-blur
+    transforms: *rotate-180
 
 - A:
     drop: 0.5
     transforms: *none
   B:
     drop: 0.0
-    transforms: *little-blur
+    transforms: *rotate-180
 
 - A:
     drop: 0.5
     transforms: *none
   B:
     drop: 0.5
-    transforms: *little-blur
+    transforms: *rotate-180
 
 - A:
     drop: 0.75
     transforms: *none
   B:
     drop: 0.25
-    transforms: *little-blur
+    transforms: *rotate-180
 
 - A:
     drop: 0.25
     transforms: *none
   B:
     drop: 0.75
-    transforms: *little-blur
+    transforms: *rotate-180

--- a/configs/metrics/pad.yaml
+++ b/configs/metrics/pad.yaml
@@ -48,7 +48,6 @@ metrics:
         batch_size: 16
         device: cuda
         n_components: 50
-        random_seed: 42
       test_proportion: 0.2
       balance_train: True
       balance_test: True
@@ -66,7 +65,6 @@ metrics:
         batch_size: 16
         device: cuda
         n_components: 50
-        random_seed: 42
       test_proportion: 0.2
       balance_train: True
       balance_test: True

--- a/scripts/generate_metrics_scripts.py
+++ b/scripts/generate_metrics_scripts.py
@@ -81,6 +81,7 @@ def main(
             combinations=combinations,
             account_name=account_name,
             experiment_names=experiment_names,
+            metric_name=metrics_file,
             conda_env_path=conda_env_path,
             generated_script_names=script_names,
         )

--- a/scripts/templates/slurm-metrics-template.sh
+++ b/scripts/templates/slurm-metrics-template.sh
@@ -6,7 +6,7 @@
 #SBATCH --gpus 1
 #SBATCH --cpus-per-gpu 36
 #SBATCH --job-name ms2-{{experiment_name}}
-#SBATCH --output ./slurm_metrics_logs/{{experiment_name}}-metrics-%j.out
+#SBATCH --output ./slurm_metrics_logs/{{experiment_name}}-metrics-{{metric_name}}-%j.out
 
 module purge
 module load baskerville

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -132,16 +132,14 @@ def generate_adversarial_images(
 
         # Prepare new set of images and successes
         new_advs = [images for _ in epsilons]
-        new_success = [
-            torch.tensor([False for _ in range(images.shape[0])], device=device)
-            for _ in epsilons
-        ]
+        new_success = torch.tensor(
+            [[False for _ in range(images.shape[0])] for _ in epsilons], device=device
+        )
 
         # Replace original images and successes with ones from the attack
         for i in range(len(epsilons)):
             new_advs[i][starting_indices] = clipped_advs[i]
             new_success[i][starting_indices] = success[i]
-            new_success[i] = new_success[i].tolist()
 
         # Overwrite to continue as normal
         clipped_advs = new_advs

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -131,10 +131,9 @@ def generate_adversarial_images(
         ]
 
         # Prepare new set of images and successes
-        new_advs = [images for _ in range(len(epsilons))]
+        new_advs = [images for _ in epsilons]
         new_success = [
-            torch.tensor([False for _ in range(images.shape[0])])
-            for _ in range(len(epsilons))
+            torch.tensor([False for _ in range(images.shape[0])]) for _ in epsilons
         ]
 
         # Replace original images and successes with ones from the attack
@@ -147,8 +146,8 @@ def generate_adversarial_images(
         clipped_advs = new_advs
         success = new_success
 
-    else:
-        # Generate advs images as normal for other attacks
+    # If not Boundary Attack, generate images as normal
+    if attack_fn_name != "BoundaryAttack":
         attack = getattr(fb.attacks, attack_fn_name)(**kwargs)
         _, clipped_advs, success = attack(fmodel, images, labels, epsilons=epsilons)
 

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -133,7 +133,8 @@ def generate_adversarial_images(
         # Prepare new set of images and successes
         new_advs = [images for _ in epsilons]
         new_success = [
-            torch.tensor([False for _ in range(images.shape[0])]) for _ in epsilons
+            torch.tensor([False for _ in range(images.shape[0])], device=device)
+            for _ in epsilons
         ]
 
         # Replace original images and successes with ones from the attack


### PR DESCRIPTION
This PR:

- Resolves #68 by adding extra code to `generate_adversarial_images` that manually initialises the Boundary Attack, then filters out unsuccessful initialisations before adding them back in and noting them as failed examples
- Includes the fix that allowed the PAD configs to run
- Adds the metric name to the slurm file logs. Far too late to be useful, but it's been a small annoyance while running stuff that will at least be resolved when we do any reruns (or if we do add OT)

One thing to note: I've reused the default initialisation in the foolbox source code, found here: <https://github.com/fotinidelig/foolbox/blob/48060e5e1ed157c427ed2eb85e6325b409578023/foolbox/attacks/boundary_attack.py#L111>

However, in the foolbox source code, this attack is intialised with the following arguments:

```python
LinearSearchBlendedUniformNoiseAttack(steps=50)
```

If you look at the foolbox documentation however, it's clear a distance argument needs to be supplied: <https://foolbox.readthedocs.io/en/v3.3.1/modules/attacks.html#foolbox.attacks.LinearSearchBlendedUniformNoiseAttack>

And indeed - if a distance isn't supplied, an error is produced. I've therefore intialised as follows:

```python
LinearSearchBlendedUniformNoiseAttack(distance=fb.distances.LpDistance(p=2), steps=50)
```

The distance choice was the only one I found in foolbox, but the choice of `p=2` is arbitrary.

We'll likely need to rerun all attacks including previously successful ones to ensure consistency and replicability as a consequence.

I've run the new code on baskerville with one of the attacks that were previously failing and can confirm it now works as expected. I'll wait until this PR is merged before re-running the attacks in full.