### PR TITLE
Model Vulnerability Metrics + Inception-Only Config

### DIFF
--- a/configs/metrics/inception.yaml
+++ b/configs/metrics/inception.yaml
@@ -72,7 +72,7 @@ metrics:
         - 0.1
         - 1
         - 10
-      embedding_name: inception_umap
+      embedding_name: inception
       embedding_kwargs:
         batch_size: 16
         device: cuda

--- a/configs/metrics/inception.yaml
+++ b/configs/metrics/inception.yaml
@@ -1,0 +1,99 @@
+baskerville: True
+metrics:
+  mmd_rbf_inception:
+    class: mmd
+    arguments:
+      kernel_name: rbf
+      embedding_name: inception
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+  otdd_exact_inception:
+    class: otdd
+    arguments:
+      # Data embedding:
+      embedding_name: inception
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+
+      # Arguments used here are defaults unless otherwise specified. Please
+      # see the source code for a description of what each parameter is:
+      # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L67
+      # general arguments
+      method: precomputed_labeldist
+      symmetric_tasks: False
+      feature_cost: euclidean
+      src_embedding: null
+      tgt_embedding: null
+      ignore_source_labels: False
+      ignore_target_labels: False
+
+      # Outer OT (dataset to dataset) problem arguments
+      loss: sinkhorn
+      debiased_loss: True
+      p: 2
+      entreg: 0.1
+      λ_x: 1.0
+      λ_y: 1.0
+
+      ## Inner OT (label to label) problem arguments
+      inner_ot_method: exact #changed from gaussian_approx
+      inner_ot_loss: sinkhorn
+      inner_ot_debiased: True #changed from False
+      inner_ot_p: 2
+      inner_ot_entreg: 0.1
+
+      # Gaussian Approximation Args
+      diagonal_cov: False
+      min_labelcount: 2
+      online_stats: True
+      sqrt_method: spectral
+      sqrt_niters: 20
+      sqrt_pref: 0
+      nworkers_stats: 0
+
+      # Misc
+      coupling_method: geomloss
+      nworkers_dists: 0
+      eigen_correction: False
+      device: cuda #changed from CPU
+      precision: single
+      verbose: 1
+
+      # dist.distance() args
+      # https://github.com/alan-turing-institute/arc-otdd/blob/main/otdd/pytorch/distance.py#L622
+      max_samples: 10000
+  pad_linear_inception:
+    class: pad
+    arguments:
+      kernel_name: linear
+      c_values:
+        - 0.1
+        - 1
+        - 10
+      embedding_name: inception_umap
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+      test_proportion: 0.2
+      balance_train: True
+      balance_test: True
+  pad_rbf_inception:
+    class: pad
+    arguments:
+      kernel_name: rbf
+      c_values:
+        - 0.1
+        - 1
+        - 10
+      gamma_values:
+        - 'scale'
+        - 'auto'
+      embedding_name: inception
+      embedding_kwargs:
+        batch_size: 16
+        device: cuda
+      test_proportion: 0.2
+      balance_train: True
+      balance_test: True

--- a/scripts/attack.py
+++ b/scripts/attack.py
@@ -4,7 +4,7 @@ import os
 import yaml
 from utils import opts2dmpairArgs
 
-from modsim2.attack import compute_transfer_attack, generate_over_combinations
+from modsim2.attack import compute_attack_metrics, generate_over_combinations
 from modsim2.data.loader import DMPair
 from modsim2.model.load_model import download_AB_models
 from modsim2.model.utils import get_wandb_run
@@ -105,7 +105,7 @@ def main(
     # Transfer attack over model*dist combinations, comptue succes
     # Names: AB_to_B imples attack trained on model A with images from distribution B,
     # transferred to model B
-    transfer_metrics_AA_to_B = compute_transfer_attack(
+    transfer_metrics_AA_to_B = compute_attack_metrics(
         model=model_B,
         images=images_A,
         labels=labels_A,
@@ -118,7 +118,7 @@ def main(
         devices=devices,
         accelerator=accelerator,
     )
-    transfer_metrics_AB_to_B = compute_transfer_attack(
+    transfer_metrics_AB_to_B = compute_attack_metrics(
         model=model_B,
         images=images_B,
         labels=labels_B,
@@ -131,7 +131,7 @@ def main(
         devices=devices,
         accelerator=accelerator,
     )
-    transfer_metrics_BA_to_A = compute_transfer_attack(
+    transfer_metrics_BA_to_A = compute_attack_metrics(
         model=model_A,
         images=images_A,
         labels=labels_A,
@@ -144,7 +144,7 @@ def main(
         devices=devices,
         accelerator=accelerator,
     )
-    transfer_metrics_BB_to_A = compute_transfer_attack(
+    transfer_metrics_BB_to_A = compute_attack_metrics(
         model=model_A,
         images=images_B,
         labels=labels_B,

--- a/scripts/attack.py
+++ b/scripts/attack.py
@@ -72,6 +72,7 @@ def main(
         attack_fn_name=attack_names[0],
         epsilons=fga_epsilons,
         device=accelerator,
+        batch_size=attack_config["batch_size"],
     )
     boundary_images = generate_over_combinations(
         model_A=model_A,
@@ -83,6 +84,7 @@ def main(
         attack_fn_name=attack_names[1],
         epsilons=ba_epsilons,
         device=accelerator,
+        batch_size=attack_config["batch_size"],
         steps=500,
     )
 

--- a/scripts/generate_metrics_scripts.py
+++ b/scripts/generate_metrics_scripts.py
@@ -81,7 +81,6 @@ def main(
             combinations=combinations,
             account_name=account_name,
             experiment_names=experiment_names,
-            metric_name=metrics_file,
             conda_env_path=conda_env_path,
             generated_script_names=script_names,
         )

--- a/scripts/templates/slurm-metrics-template.sh
+++ b/scripts/templates/slurm-metrics-template.sh
@@ -6,7 +6,7 @@
 #SBATCH --gpus 1
 #SBATCH --cpus-per-gpu 36
 #SBATCH --job-name ms2-{{experiment_name}}
-#SBATCH --output ./slurm_metrics_logs/{{experiment_name}}-metrics-{{metric_name}}-%j.out
+#SBATCH --output ./slurm_metrics_logs/{{experiment_name}}-metrics-%j.out
 
 module purge
 module load baskerville

--- a/src/modsim2/attack/__init__.py
+++ b/src/modsim2/attack/__init__.py
@@ -1,2 +1,2 @@
 from modsim2.attack.adversarial_images import generate_over_combinations  # noqa: F401
-from modsim2.attack.transfer import compute_transfer_attack  # noqa: F401
+from modsim2.attack.metrics import compute_attack_metrics  # noqa: F401

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -118,7 +118,7 @@ def boundary_attack_fn(
     # Prepare new set of images and successes
     new_advs = [images for _ in epsilons]
     new_success = torch.zeros(
-        (images.shape[0], len(epsilons)), dtype=torch.bool, device=device
+        (len(epsilons), images.shape[0]), dtype=torch.bool, device=device
     )
 
     # Replace original images and successes with ones from the attack
@@ -203,7 +203,7 @@ def generate_adversarial_images(
         _, clipped_advs, success = attack(fmodel, images, labels, epsilons=epsilons)
 
     # Apply image selection based on attack choice
-    advs_images, advs_success = select_best_attack(
+    advs_images, _ = select_best_attack(
         images=clipped_advs, success=success, epsilons=epsilons
     )
 

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -159,8 +159,10 @@ def generate_adversarial_images(
         loss_function: Callable = torch.nn.functional.nll_loss,
         **kwargs: Additional arguments based to attack setup
 
-    Returns: a torch.tensor containing the adversarial images and a torch.tensor
-             where each element contains a dictionary of model vulnerability metrics
+    Returns: a torch.tensor containing the adversarial images and a ductionary
+             where each element is a model vulnerability metric. These are
+             'success_rate' and 'mean_loss_increase' respectively.
+
     """
     # Check for valid attack choices
     if attack_fn_name not in ["L2FastGradientAttack", "BoundaryAttack"]:

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -160,8 +160,7 @@ def generate_adversarial_images(
         **kwargs: Additional arguments based to attack setup
 
     Returns: a torch.tensor containing the adversarial images and a torch.tensor
-             where each element represents the percentage of successful attacks at
-             each value of epsilon
+             where each element contains a dictionary of model vulnerability metrics
     """
     # Check for valid attack choices
     if attack_fn_name not in ["L2FastGradientAttack", "BoundaryAttack"]:

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -5,7 +5,7 @@ import foolbox as fb
 import torch
 from tqdm import tqdm
 
-from modsim2.attack.transfer import compute_transfer_attack
+from modsim2.attack.metrics import compute_attack_metrics
 from modsim2.model.resnet import ResnetModel
 from modsim2.utils.accelerator import choose_auto_accelerator
 
@@ -160,7 +160,7 @@ def generate_adversarial_images(
         loss_function: Callable = torch.nn.functional.nll_loss,
         **kwargs: Additional arguments based to attack setup
 
-    Returns: a torch.tensor containing the adversarial images and a ductionary
+    Returns: a torch.tensor containing the adversarial images and a dictionary
              where each element is a model vulnerability metric. These are
              'success_rate' and 'mean_loss_increase' respectively.
 
@@ -210,7 +210,7 @@ def generate_adversarial_images(
     )
 
     # Get the model vulnerability metrics
-    vuln = compute_transfer_attack(
+    vuln = compute_attack_metrics(
         model=model,
         images=images,
         labels=labels,

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -269,7 +269,8 @@ def generate_over_combinations(
         trainer_kwargs: Keyword arguments passed to pytorch_lightning.Trainer()
         **kwargs: Arguments passed to the attack function
 
-    Returns: A dictionary of 4 sets of adverisal images
+    Returns: A dictionary of 4 sets of adverisal images with associated model
+             vulnerability metrics
     """
     # Make dict of adversarial images
     # 4 elements, w/ keys like model_A_dist_A

--- a/src/modsim2/attack/adversarial_images.py
+++ b/src/modsim2/attack/adversarial_images.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Callable
 
 import foolbox as fb
@@ -116,7 +117,7 @@ def boundary_attack_fn(
     ]
 
     # Prepare new set of images and successes
-    new_advs = [images for _ in epsilons]
+    new_advs = [copy.deepcopy(images) for _ in epsilons]
     new_success = torch.zeros(
         (len(epsilons), images.shape[0]), dtype=torch.bool, device=device
     )

--- a/src/modsim2/attack/metrics.py
+++ b/src/modsim2/attack/metrics.py
@@ -49,7 +49,7 @@ def compute_mean_loss_rate(
     return mean_loss_rate
 
 
-def compute_transfer_attack(
+def compute_attack_metrics(
     model: ResnetModel,
     images: torch.tensor,
     labels: torch.tensor,

--- a/src/modsim2/attack/transfer.py
+++ b/src/modsim2/attack/transfer.py
@@ -79,8 +79,8 @@ def compute_transfer_attack(
         model: The model to transfer the attacks to
         images: A torch.tensor of base images
         labels: A list of correct labels corresponding to each image
-        advs_images: A torch.tensor of adversial images, which corresponds to the base
-                     images
+        advs_images: A list of torch.tensor of adversial images, which corresponds to
+                     the base images
         attack_names: Output strings for the attack names
         batch_size: Batch size for the dataloader used in predicting outputs
         loss_function: Loss function to use in computing mean_loss_rate

--- a/tests/test_attack_metrics.py
+++ b/tests/test_attack_metrics.py
@@ -1,6 +1,6 @@
 import torch
 
-from modsim2.attack.transfer import compute_mean_loss_rate, compute_success_rate
+from modsim2.attack.metrics import compute_mean_loss_rate, compute_success_rate
 
 
 def test_success_rate():


### PR DESCRIPTION
This PR:

- Replaces the old measure of model vulnerability with the same measures used for transfer success
- Updates both the attack script and src/ files to achieve this
- Adds the inception-only config with MMD, OTDD, and PAD. Does not include KDE as these required a small number of features to work well
- Some fixes/corrections

I have run another of the previously failing attacks and can confirm everything is working as expected on Baskerville